### PR TITLE
gvle: remove deprecated fields

### DIFF
--- a/src/vle/gvle/DynamicBox.cpp
+++ b/src/vle/gvle/DynamicBox.cpp
@@ -68,18 +68,6 @@ DynamicBox::DynamicBox(const Glib::RefPtr < Gtk::Builder >& xml,
         mBoxDynamicPackage->pack_start(*mComboPackage);
     }
 
-    xml->get_widget("EntryDynamicLocationHost", mLocationHost);
-    xml->get_widget("SpinbuttonDynamicLocationPort", mLocationPort);
-
-    {
-        xml->get_widget("HboxDynamicLanguage", mBoxDynamicLanguage);
-        mLanguage = Gtk::manage(new Gtk::ComboBoxText());
-        mBoxDynamicLanguage->pack_start(*mLanguage);
-        mLanguage->show();
-        mLanguage->append_text("c++");
-        mLanguage->append_text("python");
-    }
-
     xml->get_widget("buttonNewDynamicLibrary", mButtonNew);
 
     mList.push_back(mButtonNew->signal_clicked().connect(
@@ -97,7 +85,6 @@ DynamicBox::~DynamicBox()
 
     mBoxDynamicLibrary->remove(*mComboLibrary);
     mBoxDynamicPackage->remove(*mComboPackage);
-    mBoxDynamicLanguage->remove(*mLanguage);
 }
 
 void DynamicBox::show(vpz::Dynamic* dyn)
@@ -107,12 +94,6 @@ void DynamicBox::show(vpz::Dynamic* dyn)
     mDialog->set_title((fmt(_("Dynamics: %1%")) % dyn->name()).str());
     makeComboPackage();
     makeComboLibrary();
-
-    if (dyn->language().empty()) {
-        mLanguage->set_active_text("c++");
-    } else {
-        mLanguage->set_active_text(dyn->language());
-    }
 
     if (mDialog->run() == Gtk::RESPONSE_OK) {
         mDialog->hide();
@@ -171,12 +152,6 @@ void DynamicBox::on_apply()
 
     mDyn->setLibrary(mComboLibrary->get_active_text());
     mDyn->setPackage(mComboPackage->get_active_text());
-
-    if (mLanguage->get_active_text() == "c++") {
-        mDyn->setLanguage("");
-    } else {
-        mDyn->setLanguage(mLanguage->get_active_text());
-    }
 }
 
 void DynamicBox::on_cancel()

--- a/src/vle/gvle/DynamicBox.hpp
+++ b/src/vle/gvle/DynamicBox.hpp
@@ -82,15 +82,11 @@ namespace vle { namespace gvle {
         Gtk::Dialog*                        mDialog;
         Gtk::ComboBoxText*                  mComboLibrary;
         Gtk::ComboBoxText*                  mComboPackage;
-        Gtk::Entry*                         mLocationHost;
-        Gtk::SpinButton*                    mLocationPort;
-        Gtk::ComboBoxText*                  mLanguage;
         Gtk::Button*                        mButtonNew;
         vpz::Dynamic*                       mDyn;
 
         Gtk::HBox* mBoxDynamicLibrary;
         Gtk::HBox* mBoxDynamicPackage;
-        Gtk::HBox* mBoxDynamicLanguage;
 
         std::list < sigc::connection >      mList;
 

--- a/src/vle/gvle/DynamicsBox.cpp
+++ b/src/vle/gvle/DynamicsBox.cpp
@@ -46,9 +46,6 @@ DynamicsBox::DynamicsBox(Modeling& modeling,
     mXml->get_widget("treeviewDialogDynamics", mDynamics);
     mXml->get_widget("comboboxPackage", mPackage);
     mXml->get_widget("comboboxLibrary", mLibrary);
-    mXml->get_widget("entryLocation", mLocationHost);
-    mXml->get_widget("spinbuttonLocation", mLocationPort);
-    mXml->get_widget("comboboxLanguage", mLanguage);
 
     initDynamics();
     fillDynamics();
@@ -57,9 +54,6 @@ DynamicsBox::DynamicsBox(Modeling& modeling,
     fillPackage();
 
     initLibrary();
-
-    initLanguage();
-    fillLanguage();
 
     initMenuPopupDynamics();
 
@@ -346,9 +340,6 @@ void DynamicsBox::sensitive(bool active)
 {
     mPackage->set_sensitive(active);
     mLibrary->set_sensitive(active);
-    mLocationHost->set_sensitive(active);
-    mLocationPort->set_sensitive(active);
-    mLanguage->set_sensitive(active);
 }
 
 bool DynamicsBox::onButtonRealeaseDynamics(GdkEventButton* event)
@@ -414,12 +405,6 @@ void DynamicsBox::assignDynamic(const std::string& name)
 
     dyn.setPackage(getPackageStr());
 
-    if (getLanguageStr() == "c++") {
-        dyn.setLanguage("");
-    } else {
-        dyn.setLanguage(getLanguageStr());
-    }
-
     dyn.setLibrary(getLibraryStr());
 }
 
@@ -434,11 +419,6 @@ void DynamicsBox::updateDynamic(const std::string& name)
     fillLibrary();
     setLibraryStr(dyn.library());
 
-    if (dyn.language().empty()) {
-        setLanguageStr("c++");
-    } else {
-        setLanguageStr(dyn.language());
-    }
 }
 
 void DynamicsBox::applyRenaming()
@@ -548,6 +528,9 @@ void DynamicsBox::fillLibrary()
         }
         it++;
     }
+
+    mLibraryListStore->set_sort_column(0, Gtk::SORT_ASCENDING);
+
     mLibrary->pack_start(mLibraryColumns.mContent);
 }
 
@@ -571,50 +554,6 @@ Glib::ustring DynamicsBox::getLibraryStr()
         Gtk::TreeModel::Row row = *iter;
         if(row)
             return row[mLibraryColumns.mContent];
-    }
-    return "";
-}
-
-void DynamicsBox::initLanguage()
-{
-    mLanguageListStore = Gtk::ListStore::create(mLanguageColumns);
-    mLanguage->set_model(mLanguageListStore);
-}
-
-void DynamicsBox::fillLanguage()
-{
-    mLanguage->clear();
-    mLanguageListStore->clear();
-
-    mRowLanguage = *(mLanguageListStore->append());
-    mRowLanguage[mLanguageColumns.mContent] = "c++";
-
-    mRowLanguage = *(mLanguageListStore->append());
-    mRowLanguage[mLanguageColumns.mContent] = "python";
-
-    mLanguage->pack_start(mLanguageColumns.mContent);
-}
-
-void DynamicsBox::setLanguageStr(Glib::ustring str)
-{
-    const Gtk::TreeModel::Children& child = mLanguageListStore->children();
-    Gtk::TreeModel::Children::const_iterator it = child.begin();
-    while (it != child.end()) {
-        if (it and (*it)[mLanguageColumns.mContent] == str) {
-            mLanguage->set_active(it);
-        }
-        ++it;
-    }
-}
-
-Glib::ustring DynamicsBox::getLanguageStr()
-{
-    Gtk::TreeModel::iterator iter = mLanguage->get_active();
-    if (iter)
-    {
-        Gtk::TreeModel::Row row = *iter;
-        if (row)
-            return row[mLanguageColumns.mContent];
     }
     return "";
 }

--- a/src/vle/gvle/DynamicsBox.hpp
+++ b/src/vle/gvle/DynamicsBox.hpp
@@ -85,9 +85,6 @@ namespace vle { namespace gvle {
         Gtk::TreeView*                      mDynamics;
         Gtk::ComboBox*                      mPackage;
         Gtk::ComboBox*                      mLibrary;
-        Gtk::Entry*                         mLocationHost;
-        Gtk::SpinButton*                    mLocationPort;
-        Gtk::ComboBox*                      mLanguage;
 
         Gtk::CellRendererText*              mCellRenderer;
         int                                 mColumnName;
@@ -101,10 +98,8 @@ namespace vle { namespace gvle {
 
         Glib::RefPtr<Gtk::ListStore>        mDynamicsListStore;
         Glib::RefPtr<Gtk::ListStore>        mPackageListStore;
-        Glib::RefPtr<Gtk::ListStore>        mLanguageListStore;
         Glib::RefPtr<Gtk::ListStore>        mLibraryListStore;
 
-        Gtk::TreeModel::Row                 mRowLanguage;
         Gtk::TreeModel::Row                 mRowPackage;
         Gtk::TreeModel::Row                 mRowLibrary;
 
@@ -136,11 +131,6 @@ namespace vle { namespace gvle {
         void setPackageStr(Glib::ustring str);
         Glib::ustring getPackageStr();
 
-        void initLanguage();
-        void fillLanguage();
-        void setLanguageStr(Glib::ustring str);
-        Glib::ustring getLanguageStr();
-
         void initLibrary();
         void fillLibrary();
         void setLibraryStr(Glib::ustring str);
@@ -166,14 +156,6 @@ namespace vle { namespace gvle {
 
             Gtk::TreeModelColumn<Glib::ustring> mContent;
         } mPackageColumns;
-
-        struct LanguageModelColumns : public Gtk::TreeModel::ColumnRecord
-        {
-            LanguageModelColumns()
-            { add(mContent); }
-
-            Gtk::TreeModelColumn<Glib::ustring> mContent;
-        } mLanguageColumns;
 
         struct LibraryModelColumns : public Gtk::TreeModel::ColumnRecord
         {

--- a/src/vle/gvle/gvle.glade
+++ b/src/vle/gvle/gvle.glade
@@ -1067,49 +1067,6 @@ Retired Contributors
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area8">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="ButtonDynamicCancel">
-                <property name="label">gtk-cancel</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ButtonDynamicApply">
-                <property name="label">gtk-ok</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
         <child>
           <object class="GtkFrame" id="frame24">
             <property name="visible">True</property>
@@ -1198,62 +1155,6 @@ Retired Contributors
                         <property name="position">1</property>
                       </packing>
                     </child>
-                    <child>
-                      <object class="GtkHBox" id="hbox18">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
-                          <object class="GtkLabel" id="label31">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Model</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">10</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="EntryDynamicModel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="primary_icon_activatable">False</property>
-                            <property name="secondary_icon_activatable">False</property>
-                            <property name="primary_icon_sensitive">True</property>
-                            <property name="secondary_icon_sensitive">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="padding">10</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label59">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">&lt;span style="oblique" size="medium" foreground="grey50"&gt;The Model corresponds to the 'xxx' from DECLARE_NAMED_DYNAMICS(xxx, yyy)
-in the C++ source code. Library is the name of the shared library which
-containts your devs::Dynamics source code&lt;/span&gt;</property>
-                        <property name="use_markup">True</property>
-                        <property name="justify">right</property>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">3</property>
-                      </packing>
-                    </child>
                   </object>
                 </child>
               </object>
@@ -1270,153 +1171,50 @@ containts your devs::Dynamics source code&lt;/span&gt;</property>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
           </packing>
         </child>
-        <child>
-          <object class="GtkExpander" id="expander1">
+        <child internal-child="action_area">
+          <object class="GtkHButtonBox" id="dialog-action_area8">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="use_markup">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
             <child>
-              <object class="GtkFrame" id="frame25">
+              <object class="GtkButton" id="ButtonDynamicCancel">
+                <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label_xalign">0</property>
-                <property name="shadow_type">etched-out</property>
-                <child>
-                  <object class="GtkAlignment" id="alignment30">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="left_padding">10</property>
-                    <property name="right_padding">10</property>
-                    <child>
-                      <object class="GtkVBox" id="vbox24">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
-                          <object class="GtkHBox" id="hbox17">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkLabel" id="label30">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Location</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">10</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkEntry" id="EntryDynamicLocationHost">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="primary_icon_activatable">False</property>
-                                <property name="secondary_icon_activatable">False</property>
-                                <property name="primary_icon_sensitive">True</property>
-                                <property name="secondary_icon_sensitive">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label32">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes"> : </property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">10</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSpinButton" id="SpinbuttonDynamicLocationPort">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="primary_icon_activatable">False</property>
-                                <property name="secondary_icon_activatable">False</property>
-                                <property name="primary_icon_sensitive">True</property>
-                                <property name="secondary_icon_sensitive">True</property>
-                                <property name="numeric">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">3</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">10</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkHBox" id="HboxDynamicLanguage">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkLabel" id="label33">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">language</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">10</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">10</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel" id="label57">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="use_markup">True</property>
-                  </object>
-                </child>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
+                <property name="use_stock">True</property>
               </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
             </child>
-            <child type="label">
-              <object class="GtkLabel" id="label58">
+            <child>
+              <object class="GtkButton" id="ButtonDynamicApply">
+                <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">&lt;b&gt;advanced parameters&lt;/b&gt;</property>
-                <property name="use_markup">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_action_appearance">False</property>
+                <property name="use_stock">True</property>
               </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
+            <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -1643,65 +1441,6 @@ containts your devs::Dynamics source code&lt;/span&gt;</property>
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
-                                <child>
-                                  <object class="GtkHBox" id="hbox4b">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <child>
-                                      <object class="GtkLabel" id="label8b">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">Model</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkEntry" id="entryModel">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="invisible_char">●</property>
-                                        <property name="primary_icon_activatable">False</property>
-                                        <property name="secondary_icon_activatable">False</property>
-                                        <property name="primary_icon_sensitive">True</property>
-                                        <property name="secondary_icon_sensitive">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label5b">
-                                    <property name="visible">True</property>
-                                    <property name="sensitive">False</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">The Model corresponds to the 'xxx' from DECLARE_NAMES_DYNAMICS(xxx,yyy)
-in the C++ source code. Library is the name of the shared library which
-contains your devs::Dynamics source code</property>
-                                    <property name="use_markup">True</property>
-                                    <property name="justify">right</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
                               </object>
                             </child>
                           </object>
@@ -1721,177 +1460,6 @@ contains your devs::Dynamics source code</property>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkExpander" id="expander1b">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <child>
-                      <object class="GtkAlignment" id="alignment3b">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="top_padding">5</property>
-                        <property name="bottom_padding">5</property>
-                        <property name="left_padding">10</property>
-                        <property name="right_padding">10</property>
-                        <child>
-                          <object class="GtkFrame" id="frame2b">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label_xalign">0</property>
-                            <property name="label_yalign">0</property>
-                            <property name="shadow_type">etched-out</property>
-                            <child>
-                              <object class="GtkAlignment" id="alignment5b">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="bottom_padding">10</property>
-                                <property name="left_padding">10</property>
-                                <property name="right_padding">10</property>
-                                <child>
-                                  <object class="GtkVBox" id="vbox3b">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="spacing">10</property>
-                                    <child>
-                                      <object class="GtkHBox" id="hbox5b">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label9b">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Location</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="padding">5</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkEntry" id="entryLocation">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="invisible_char">●</property>
-                                            <property name="primary_icon_activatable">False</property>
-                                            <property name="secondary_icon_activatable">False</property>
-                                            <property name="primary_icon_sensitive">True</property>
-                                            <property name="secondary_icon_sensitive">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="padding">5</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="label10b">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">:</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="padding">5</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spinbuttonLocation">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="invisible_char">●</property>
-                                            <property name="primary_icon_activatable">False</property>
-                                            <property name="secondary_icon_activatable">False</property>
-                                            <property name="primary_icon_sensitive">True</property>
-                                            <property name="secondary_icon_sensitive">True</property>
-                                            <property name="snap_to_ticks">True</property>
-                                            <property name="numeric">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="padding">5</property>
-                                            <property name="position">3</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkHBox" id="hbox6b">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label11b">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Language</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="padding">5</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkComboBox" id="comboboxLanguage">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="padding">5</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label">
-                              <object class="GtkLabel" id="label3b">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="use_markup">True</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child type="label">
-                      <object class="GtkLabel" id="label2b">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">&lt;b&gt;Advanced Parameters&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="pack_type">end</property>
-                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>


### PR DESCRIPTION
According to the new dynamics managment system of vle-1.1, a library
does only host a single model. By the way other remaining deprecated
fields have been removed. And the Library combobox is sorted by name.
