### PR TITLE
Remove unecessary headers

### DIFF
--- a/src/vle/devs/Attribute.hpp
+++ b/src/vle/devs/Attribute.hpp
@@ -36,7 +36,6 @@
 #include <vle/value/Boolean.hpp>
 #include <vle/value/Map.hpp>
 #include <vle/value/Set.hpp>
-#include <utility>
 #include <string>
 
 namespace vle { namespace devs {

--- a/src/vle/devs/Coordinator.cpp
+++ b/src/vle/devs/Coordinator.cpp
@@ -28,21 +28,15 @@
 #include <vle/devs/Coordinator.hpp>
 #include <vle/devs/RootCoordinator.hpp>
 #include <vle/devs/Dynamics.hpp>
-#include <vle/devs/Executive.hpp>
 #include <vle/devs/Simulator.hpp>
 #include <vle/devs/ExternalEvent.hpp>
 #include <vle/devs/InternalEvent.hpp>
 #include <vle/devs/ExternalEventList.hpp>
-#include <vle/devs/ObservationEvent.hpp>
-#include <vle/devs/ModelFactory.hpp>
 #include <vle/devs/StreamWriter.hpp>
 #include <vle/vpz/BaseModel.hpp>
 #include <vle/vpz/AtomicModel.hpp>
 #include <vle/vpz/CoupledModel.hpp>
-#include <vle/utils/Tools.hpp>
 #include <vle/utils/Trace.hpp>
-#include <vle/utils/Path.hpp>
-#include <vle/value/Value.hpp>
 
 using std::vector;
 using std::map;

--- a/src/vle/devs/Coordinator.hpp
+++ b/src/vle/devs/Coordinator.hpp
@@ -34,8 +34,6 @@
 #include <vle/devs/View.hpp>
 #include <vle/devs/Time.hpp>
 #include <vle/devs/ModelFactory.hpp>
-#include <vle/vpz/Vpz.hpp>
-#include <vle/oov/Plugin.hpp>
 
 namespace vle { namespace devs {
 

--- a/src/vle/devs/Dynamics.cpp
+++ b/src/vle/devs/Dynamics.cpp
@@ -25,16 +25,12 @@
  */
 
 
-#include <vle/devs/InternalEvent.hpp>
 #include <vle/devs/ExternalEvent.hpp>
-#include <vle/devs/EventList.hpp>
 #include <vle/devs/Dynamics.hpp>
-#include <vle/devs/Simulator.hpp>
 #include <vle/value/Double.hpp>
 #include <vle/value/Integer.hpp>
 #include <vle/value/Boolean.hpp>
 #include <vle/value/String.hpp>
-#include <vle/utils/Tools.hpp>
 #include <vle/utils/Path.hpp>
 #include <vle/utils/Package.hpp>
 

--- a/src/vle/devs/Dynamics.hpp
+++ b/src/vle/devs/Dynamics.hpp
@@ -31,8 +31,6 @@
 #include <vle/DllDefines.hpp>
 #include <vle/devs/Time.hpp>
 #include <vle/devs/EventList.hpp>
-#include <vle/devs/EventTable.hpp>
-#include <vle/devs/InternalEvent.hpp>
 #include <vle/devs/ExternalEvent.hpp>
 #include <vle/devs/ExternalEventList.hpp>
 #include <vle/devs/ObservationEvent.hpp>

--- a/src/vle/devs/EventTable.cpp
+++ b/src/vle/devs/EventTable.cpp
@@ -28,8 +28,6 @@
 #include <vle/devs/EventTable.hpp>
 #include <vle/devs/InternalEvent.hpp>
 #include <vle/devs/ExternalEvent.hpp>
-#include <vle/devs/ExternalEventList.hpp>
-#include <vle/devs/ObservationEvent.hpp>
 
 namespace vle { namespace devs {
 

--- a/src/vle/devs/EventTable.hpp
+++ b/src/vle/devs/EventTable.hpp
@@ -31,13 +31,8 @@
 #include <vle/DllDefines.hpp>
 #include <vle/devs/InternalEvent.hpp>
 #include <vle/devs/ExternalEvent.hpp>
-#include <vle/devs/ObservationEvent.hpp>
 #include <vle/devs/ViewEvent.hpp>
-#include <vle/devs/EventList.hpp>
 #include <vle/devs/Simulator.hpp>
-#include <vle/devs/Dynamics.hpp>
-#include <string>
-#include <vector>
 #include <list>
 #include <set>
 

--- a/src/vle/devs/Executive.cpp
+++ b/src/vle/devs/Executive.cpp
@@ -26,6 +26,7 @@
 
 
 #include <vle/devs/Executive.hpp>
+#include <vle/vpz/Vpz.hpp>
 
 namespace vle { namespace devs {
 

--- a/src/vle/devs/ExecutiveDbg.hpp
+++ b/src/vle/devs/ExecutiveDbg.hpp
@@ -29,8 +29,6 @@
 #define VLE_DEVS_EXECUTIVEDBG_HPP
 
 #include <vle/DllDefines.hpp>
-#include <vle/devs/DynamicsDbg.hpp>
-#include <vle/devs/Executive.hpp>
 #include <vle/utils/i18n.hpp>
 #include <vle/utils/Trace.hpp>
 #include <vle/version.hpp>

--- a/src/vle/devs/ExternalEvent.cpp
+++ b/src/vle/devs/ExternalEvent.cpp
@@ -26,7 +26,6 @@
 
 
 #include <vle/devs/ExternalEvent.hpp>
-#include <vle/devs/Simulator.hpp>
 
 namespace vle { namespace devs {
 

--- a/src/vle/devs/ExternalEventList.hpp
+++ b/src/vle/devs/ExternalEventList.hpp
@@ -28,7 +28,6 @@
 #ifndef VLE_DEVS_EXTERNALEVENTLIST_HPP
 #define VLE_DEVS_EXTERNALEVENTLIST_HPP
 
-#include <vle/DllDefines.hpp>
 #include <vle/devs/EventList.hpp>
 #include <vle/devs/ExternalEvent.hpp>
 #include <vle/value/Map.hpp>

--- a/src/vle/devs/InternalEvent.cpp
+++ b/src/vle/devs/InternalEvent.cpp
@@ -26,7 +26,6 @@
 
 
 #include <vle/devs/InternalEvent.hpp>
-#include <string>
 
 namespace vle { namespace devs {
 

--- a/src/vle/devs/ModelFactory.cpp
+++ b/src/vle/devs/ModelFactory.cpp
@@ -35,8 +35,6 @@
 #include <vle/vpz/BaseModel.hpp>
 #include <vle/vpz/AtomicModel.hpp>
 #include <vle/vpz/CoupledModel.hpp>
-#include <vle/utils/Tools.hpp>
-#include <vle/utils/Path.hpp>
 #include <vle/utils/Package.hpp>
 #include <vle/utils/Algo.hpp>
 

--- a/src/vle/devs/RootCoordinator.cpp
+++ b/src/vle/devs/RootCoordinator.cpp
@@ -27,13 +27,6 @@
 
 #include <vle/devs/RootCoordinator.hpp>
 #include <vle/devs/Coordinator.hpp>
-#include <vle/devs/ModelFactory.hpp>
-#include <vle/devs/Dynamics.hpp>
-#include <vle/devs/ExternalEvent.hpp>
-#include <vle/devs/Time.hpp>
-#include <vle/utils/Rand.hpp>
-#include <vle/vpz/BaseModel.hpp>
-#include <cmath>
 
 namespace vle { namespace devs {
 

--- a/src/vle/devs/Simulator.cpp
+++ b/src/vle/devs/Simulator.cpp
@@ -27,12 +27,8 @@
 
 #include <vle/devs/Simulator.hpp>
 #include <vle/devs/Dynamics.hpp>
-#include <vle/devs/ExternalEvent.hpp>
 #include <vle/devs/Time.hpp>
-#include <vle/devs/Dynamics.hpp>
 #include <vle/vpz/AtomicModel.hpp>
-#include <vle/vpz/CoupledModel.hpp>
-#include <vle/value/Null.hpp>
 
 namespace vle { namespace devs {
 

--- a/src/vle/devs/Simulator.hpp
+++ b/src/vle/devs/Simulator.hpp
@@ -31,9 +31,9 @@
 #include <vle/DllDefines.hpp>
 #include <vle/devs/Time.hpp>
 #include <vle/devs/InternalEvent.hpp>
+#include <vle/devs/ObservationEvent.hpp>
 #include <vle/devs/ExternalEventList.hpp>
-#include <vle/devs/EventList.hpp>
-#include <vle/devs/EventTable.hpp>
+#include <vle/devs/Dynamics.hpp>
 #include <vle/vpz/AtomicModel.hpp>
 
 namespace vle { namespace devs {

--- a/src/vle/devs/StreamWriter.cpp
+++ b/src/vle/devs/StreamWriter.cpp
@@ -28,9 +28,11 @@
 #include <vle/devs/StreamWriter.hpp>
 #include <vle/devs/Simulator.hpp>
 #include <vle/oov/Plugin.hpp>
-#include <vle/oov/CairoPlugin.hpp>
+#ifdef VLE_HAVE_CAIRO
+  #include <vle/oov/CairoPlugin.hpp>
+  #include <vle/utils/Path.hpp>
+#endif
 #include <vle/utils/Algo.hpp>
-#include <vle/utils/Path.hpp>
 #include <vle/version.hpp>
 
 namespace vle { namespace devs {

--- a/src/vle/devs/StreamWriter.hpp
+++ b/src/vle/devs/StreamWriter.hpp
@@ -30,12 +30,11 @@
 
 #include <vle/DllDefines.hpp>
 #include <vle/devs/View.hpp>
+#include <vle/devs/Simulator.hpp>
 #include <vle/devs/Time.hpp>
 #include <vle/value/Value.hpp>
 #include <vle/oov/Plugin.hpp>
 #include <vle/utils/ModuleManager.hpp>
-#include <map>
-#include <vector>
 
 namespace vle { namespace devs {
 

--- a/src/vle/devs/View.cpp
+++ b/src/vle/devs/View.cpp
@@ -27,7 +27,6 @@
 
 #include <vle/devs/View.hpp>
 #include <vle/devs/Simulator.hpp>
-#include <vle/devs/StreamWriter.hpp>
 
 namespace vle { namespace devs {
 

--- a/src/vle/devs/View.hpp
+++ b/src/vle/devs/View.hpp
@@ -29,12 +29,11 @@
 #define VLE_DEVS_VIEW_HPP 1
 
 #include <vle/DllDefines.hpp>
+#include <vle/devs/StreamWriter.hpp>
 #include <vle/devs/Time.hpp>
-#include <vle/oov/Plugin.hpp>
-#include <vle/utils/Tools.hpp>
+#include <vle/value/Matrix.hpp>
 #include <string>
 #include <map>
-#include <vector>
 
 namespace vle { namespace devs {
 

--- a/src/vle/devs/ViewEvent.hpp
+++ b/src/vle/devs/ViewEvent.hpp
@@ -31,7 +31,6 @@
 #include <vle/DllDefines.hpp>
 #include <vle/devs/View.hpp>
 #include <vector>
-#include <cassert>
 
 namespace vle { namespace devs {
 

--- a/src/vle/manager/ExperimentGenerator.hpp
+++ b/src/vle/manager/ExperimentGenerator.hpp
@@ -29,7 +29,7 @@
 #define VLE_MANAGER_EXPERIMENTGENERATOR_HPP
 
 #include <vle/DllDefines.hpp>
-#include <vle/utils/Types.hpp>
+
 #include <vle/vpz/Vpz.hpp>
 #include <vle/vpz/Conditions.hpp>
 #include <string>

--- a/src/vle/manager/Manager.cpp
+++ b/src/vle/manager/Manager.cpp
@@ -30,14 +30,13 @@
 # define BOOST_THREAD_DONT_USE_CHRONO
 #endif
 
-#include <vle/devs/Coordinator.hpp>
 #include <vle/manager/Manager.hpp>
 #include <vle/manager/ExperimentGenerator.hpp>
 #include <vle/manager/Simulation.hpp>
 #include <vle/utils/Tools.hpp>
 #include <vle/utils/Trace.hpp>
 #include <vle/vpz/Vpz.hpp>
-#include <vle/value/Value.hpp>
+#include <vle/vpz/BaseModel.hpp>
 #include <boost/thread/thread.hpp>
 
 namespace vle { namespace manager {

--- a/src/vle/manager/Manager.hpp
+++ b/src/vle/manager/Manager.hpp
@@ -30,7 +30,6 @@
 
 #include <vle/DllDefines.hpp>
 #include <vle/utils/ModuleManager.hpp>
-#include <vle/utils/Types.hpp>
 #include <vle/manager/Types.hpp>
 #include <vle/vpz/Vpz.hpp>
 

--- a/src/vle/manager/Types.hpp
+++ b/src/vle/manager/Types.hpp
@@ -28,8 +28,6 @@
 #ifndef VLE_MANAGER_TYPES_HPP
 #define VLE_MANAGER_TYPES_HPP
 
-#include <vle/value/Matrix.hpp>
-#include <vle/value/Set.hpp>
 #include <string>
 
 namespace vle { namespace manager  {

--- a/src/vle/oov/CairoPlugin.cpp
+++ b/src/vle/oov/CairoPlugin.cpp
@@ -26,7 +26,6 @@
 
 
 #include <vle/oov/CairoPlugin.hpp>
-#include <iostream>
 
 namespace vle { namespace oov {
 

--- a/src/vle/oov/Plugin.hpp
+++ b/src/vle/oov/Plugin.hpp
@@ -29,7 +29,6 @@
 #define VLE_OOV_PLUGIN_HPP
 
 #include <vle/DllDefines.hpp>
-#include <vle/value/Set.hpp>
 #include <vle/value/Matrix.hpp>
 #include <vle/version.hpp>
 #include <boost/shared_ptr.hpp>

--- a/src/vle/oov/StreamReader.cpp
+++ b/src/vle/oov/StreamReader.cpp
@@ -28,8 +28,6 @@
 #include <vle/oov/StreamReader.hpp>
 #include <vle/oov/Plugin.hpp>
 #include <vle/utils/Algo.hpp>
-#include <vle/utils/Path.hpp>
-#include <vle/value/String.hpp>
 #include <vle/version.hpp>
 
 #ifdef VLE_HAVE_CAIRO

--- a/src/vle/oov/StreamReader.hpp
+++ b/src/vle/oov/StreamReader.hpp
@@ -31,7 +31,6 @@
 #include <vle/DllDefines.hpp>
 #include <vle/oov/Plugin.hpp>
 #include <vle/utils/ModuleManager.hpp>
-#include <boost/shared_ptr.hpp>
 #include <string>
 
 namespace vle { namespace oov {

--- a/src/vle/translator/MatrixTranslator.cpp
+++ b/src/vle/translator/MatrixTranslator.cpp
@@ -26,17 +26,10 @@
 
 
 #include <vle/translator/MatrixTranslator.hpp>
-#include <vle/devs/Coordinator.hpp>
-#include <vle/utils/Rand.hpp>
-#include <vle/utils/Tools.hpp>
 #include <vle/value/Boolean.hpp>
-#include <vle/value/Double.hpp>
 #include <vle/value/Set.hpp>
 #include <vle/value/String.hpp>
-#include <vle/value/XML.hpp>
 #include <vle/vpz/AtomicModel.hpp>
-#include <vle/vpz/CoupledModel.hpp>
-#include <boost/format.hpp>
 #include <boost/cast.hpp>
 
 namespace vle { namespace translator {

--- a/src/vle/utils/ModuleManager.cpp
+++ b/src/vle/utils/ModuleManager.cpp
@@ -25,21 +25,17 @@
  */
 
 
-#include <vle/DllDefines.hpp>
 #include <vle/utils/ModuleManager.hpp>
 #include <vle/utils/Exception.hpp>
 #include <vle/utils/i18n.hpp>
 #include <vle/utils/Algo.hpp>
 #include <vle/utils/Path.hpp>
 #include <vle/utils/Trace.hpp>
-#include <vle/utils/Types.hpp>
 #include <vle/version.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
-#include <boost/checked_delete.hpp>
 #include <boost/version.hpp>
-#include <algorithm>
 
 #ifdef BOOST_WINDOWS
 #include <windows.h>

--- a/src/vle/utils/Package.cpp
+++ b/src/vle/utils/Package.cpp
@@ -29,7 +29,6 @@
 #include <vle/utils/Path.hpp>
 #include <vle/utils/Preferences.hpp>
 #include <vle/utils/Trace.hpp>
-#include <vle/utils/Tools.hpp>
 #include <vle/utils/Exception.hpp>
 #include <vle/utils/details/Spawn.hpp>
 #include <boost/filesystem.hpp>

--- a/src/vle/utils/Package.hpp
+++ b/src/vle/utils/Package.hpp
@@ -31,7 +31,6 @@
 #include <vle/DllDefines.hpp>
 #include <vle/utils/PackageTable.hpp>
 #include <string>
-#include <vector>
 
 namespace vle { namespace utils {
 

--- a/src/vle/utils/Parser.cpp
+++ b/src/vle/utils/Parser.cpp
@@ -25,15 +25,13 @@
  */
 
 
-#include <vle/utils//Parser.hpp>
+#include <vle/utils/Parser.hpp>
 #include <vle/utils/Exception.hpp>
 #include <vle/utils/i18n.hpp>
-#include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>
 #include <vector>
 #include <string>
 #include <sstream>
-#include <iterator>
 
 namespace vle { namespace utils {
 

--- a/src/vle/utils/Parser.hpp
+++ b/src/vle/utils/Parser.hpp
@@ -31,7 +31,6 @@
 #include <vle/DllDefines.hpp>
 #include <vle/utils/Exception.hpp>
 #include <istream>
-#include <vector>
 #include <string>
 #include <map>
 

--- a/src/vle/utils/PathUnix.cpp
+++ b/src/vle/utils/PathUnix.cpp
@@ -29,12 +29,8 @@
 #include <fstream>
 
 #include <vle/utils/Path.hpp>
-#include <vle/utils/Package.hpp>
-#include <vle/utils/Exception.hpp>
 #include <vle/version.hpp>
-
 #include <glibmm/miscutils.h>
-
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
 

--- a/src/vle/utils/Rand.cpp
+++ b/src/vle/utils/Rand.cpp
@@ -27,8 +27,6 @@
 
 #include <cmath>
 #include <vle/utils/Rand.hpp>
-#include <vle/utils/Types.hpp>
-
 
 namespace vle { namespace utils {
 

--- a/src/vle/utils/RemoteManager.cpp
+++ b/src/vle/utils/RemoteManager.cpp
@@ -33,7 +33,7 @@
 #include <vle/utils/RemoteManager.hpp>
 #include <vle/utils/Algo.hpp>
 #include <vle/utils/DownloadManager.hpp>
-#include <vle/utils/Exception.hpp>
+#include <vle/utils/i18n.hpp>
 #include <vle/utils/Path.hpp>
 #include <vle/utils/Package.hpp>
 #include <vle/utils/Preferences.hpp>
@@ -43,15 +43,11 @@
 #include <vle/utils/details/PackageManager.hpp>
 #include <vle/version.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/trim.hpp>
+#include <boost/algorithm/string/classification.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/cast.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/thread/thread.hpp>
-#include <boost/unordered_map.hpp>
 #include <boost/regex.hpp>
 #include <fstream>
 #include <ostream>

--- a/src/vle/utils/Tools.cpp
+++ b/src/vle/utils/Tools.cpp
@@ -27,8 +27,6 @@
 
 #include <vle/utils/Tools.hpp>
 #include <vle/utils/Exception.hpp>
-#include <vle/utils/Trace.hpp>
-#include <vle/utils/Path.hpp>
 #include <vle/utils/i18n.hpp>
 #include <vle/version.hpp>
 #include <boost/lexical_cast.hpp>

--- a/src/vle/utils/Tools.hpp
+++ b/src/vle/utils/Tools.hpp
@@ -29,7 +29,6 @@
 #define VLE_UTILS_TOOLS_HPP
 
 #include <vle/DllDefines.hpp>
-#include <vle/utils/Types.hpp>
 #include <typeinfo>
 #include <string>
 

--- a/src/vle/utils/Trace.cpp
+++ b/src/vle/utils/Trace.cpp
@@ -30,7 +30,6 @@
 #include <vle/utils/Trace.hpp>
 #include <vle/utils/i18n.hpp>
 #include <vle/utils/Path.hpp>
-#include <vle/utils/Tools.hpp>
 #include <vle/utils/DateTime.hpp>
 #include <boost/thread.hpp>
 

--- a/src/vle/utils/details/Compress.cpp
+++ b/src/vle/utils/details/Compress.cpp
@@ -28,14 +28,11 @@
 #include <vle/utils/Path.hpp>
 #include <vle/utils/i18n.hpp>
 #include <vle/utils/Exception.hpp>
-#include <vle/utils/Types.hpp>
 #include <ostream>
 #include <fstream>
 #include <archive.h>
 #include <archive_entry.h>
 #include <fcntl.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 
 namespace vle { namespace utils {
 

--- a/src/vle/utils/details/PackageManager.hpp
+++ b/src/vle/utils/details/PackageManager.hpp
@@ -27,7 +27,7 @@
 #ifndef VLE_UTILS_DETAILS_LOCALPACKAGEMANAGER_HPP
 #define VLE_UTILS_DETAILS_LOCALPACKAGEMANAGER_HPP
 
-#include <vle/utils/details/Package.hpp>
+#include <vle/utils/RemoteManager.hpp>
 
 namespace vle { namespace utils {
 

--- a/src/vle/utils/details/PackageParser.cpp
+++ b/src/vle/utils/details/PackageParser.cpp
@@ -26,14 +26,10 @@
 
 #include <vle/utils/details/PackageParser.hpp>
 #include <vle/utils/details/Package.hpp>
-#include <vle/utils/Exception.hpp>
 #include <vle/utils/Trace.hpp>
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/algorithm/string/join.hpp>
-#include <boost/algorithm/string/split.hpp>
+#include <vle/utils/i18n.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/cast.hpp>
 #include <fstream>
 #include <cassert>
 

--- a/src/vle/utils/details/PackageParser.hpp
+++ b/src/vle/utils/details/PackageParser.hpp
@@ -28,7 +28,6 @@
 #define VLE_UTILS_DETAILS_PACKAGEPARSER_HPP
 
 #include <vle/utils/RemoteManager.hpp>
-#include <vle/utils/details/Package.hpp>
 #include <string>
 
 namespace vle { namespace utils {

--- a/src/vle/utils/details/SpawnUnix.cpp
+++ b/src/vle/utils/details/SpawnUnix.cpp
@@ -26,8 +26,6 @@
 
 #include <vle/utils/details/Spawn.hpp>
 #include <vle/utils/i18n.hpp>
-#include <sys/types.h>
-#include <sys/time.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <cerrno>

--- a/src/vle/value/Integer.hpp
+++ b/src/vle/value/Integer.hpp
@@ -29,9 +29,6 @@
 #define VLE_VALUE_INTEGER_HPP 1
 
 #include <vle/value/Value.hpp>
-#include <vle/utils/Exception.hpp>
-#include <vle/utils/i18n.hpp>
-#include <vle/utils/Types.hpp>
 #include <vle/DllDefines.hpp>
 
 namespace vle { namespace value {

--- a/src/vle/value/Map.cpp
+++ b/src/vle/value/Map.cpp
@@ -26,15 +26,10 @@
 
 
 #include <vle/value/Map.hpp>
-#include <vle/value/String.hpp>
 #include <vle/value/Set.hpp>
-#include <vle/value/Integer.hpp>
-#include <vle/value/Double.hpp>
-#include <vle/value/Boolean.hpp>
 #include <vle/value/Matrix.hpp>
-#include <vle/value/XML.hpp>
 #include <vle/utils/Algo.hpp>
-#include <boost/utility.hpp>
+#include <boost/checked_delete.hpp>
 
 namespace vle { namespace value {
 

--- a/src/vle/value/Matrix.cpp
+++ b/src/vle/value/Matrix.cpp
@@ -28,7 +28,6 @@
 #include <vle/value/Matrix.hpp>
 #include <vle/value/Set.hpp>
 #include <vle/value/Map.hpp>
-#include <boost/utility.hpp>
 
 namespace vle { namespace value {
 

--- a/src/vle/value/Set.cpp
+++ b/src/vle/value/Set.cpp
@@ -37,7 +37,6 @@
 #include <vle/value/Boolean.hpp>
 #include <vle/value/XML.hpp>
 #include <vle/value/Null.hpp>
-#include <boost/utility.hpp>
 #include <fstream>
 #include <sstream>
 

--- a/src/vle/value/Value.cpp
+++ b/src/vle/value/Value.cpp
@@ -37,7 +37,6 @@
 #include <vle/value/XML.hpp>
 #include <vle/value/Null.hpp>
 #include <vle/value/Matrix.hpp>
-#include <vle/utils/Tools.hpp>
 #include <sstream>
 #include <boost/serialization/export.hpp>
 

--- a/src/vle/value/Value.hpp
+++ b/src/vle/value/Value.hpp
@@ -29,6 +29,7 @@
 #define VLE_VALUE_VALUE_HPP 1
 
 #include <vle/version.hpp>
+#include <vle/utils/Types.hpp>
 #include <vle/utils/Exception.hpp>
 #include <vle/DllDefines.hpp>
 #include <boost/archive/text_iarchive.hpp>

--- a/src/vle/vpz/AtomicModel.hpp
+++ b/src/vle/vpz/AtomicModel.hpp
@@ -31,7 +31,7 @@
 #include <vle/DllDefines.hpp>
 #include <iterator>
 #include <string>
-#include <list>
+#include <set>
 
 namespace vle { namespace vpz {
 

--- a/src/vle/vpz/Class.cpp
+++ b/src/vle/vpz/Class.cpp
@@ -27,7 +27,6 @@
 
 #include <vle/vpz/Class.hpp>
 #include <vle/vpz/AtomicModel.hpp>
-#include <algorithm>
 
 namespace vle { namespace vpz {
 

--- a/src/vle/vpz/Condition.cpp
+++ b/src/vle/vpz/Condition.cpp
@@ -30,7 +30,6 @@
 #include <vle/utils/Exception.hpp>
 #include <vle/value/Value.hpp>
 #include <vle/value/Set.hpp>
-#include <boost/utility.hpp>
 
 namespace vle { namespace vpz {
 

--- a/src/vle/vpz/Conditions.cpp
+++ b/src/vle/vpz/Conditions.cpp
@@ -27,7 +27,6 @@
 
 #include <vle/vpz/Conditions.hpp>
 #include <vle/utils/Algo.hpp>
-#include <vle/value/Value.hpp>
 #include <algorithm>
 
 namespace vle { namespace vpz {

--- a/src/vle/vpz/CoupledModel.cpp
+++ b/src/vle/vpz/CoupledModel.cpp
@@ -27,7 +27,6 @@
 
 #include <vle/vpz/CoupledModel.hpp>
 #include <vle/vpz/AtomicModel.hpp>
-#include <vle/utils/Tools.hpp>
 #include <vle/utils/Exception.hpp>
 #include <cmath>
 #include <set>

--- a/src/vle/vpz/CoupledModel.hpp
+++ b/src/vle/vpz/CoupledModel.hpp
@@ -30,6 +30,7 @@
 
 #include <vle/vpz/BaseModel.hpp>
 #include <vle/DllDefines.hpp>
+#include <map>
 #include <vector>
 
 namespace vle { namespace vpz {

--- a/src/vle/vpz/Dynamic.cpp
+++ b/src/vle/vpz/Dynamic.cpp
@@ -26,8 +26,6 @@
 
 
 #include <vle/vpz/Dynamic.hpp>
-#include <vle/utils/Exception.hpp>
-#include <vle/utils/i18n.hpp>
 
 namespace vle { namespace vpz {
 

--- a/src/vle/vpz/Dynamics.cpp
+++ b/src/vle/vpz/Dynamics.cpp
@@ -31,6 +31,7 @@
 #include <vle/utils/i18n.hpp>
 #include <iterator>
 #include <vector>
+#include <set>
 
 namespace vle { namespace vpz {
 

--- a/src/vle/vpz/Dynamics.hpp
+++ b/src/vle/vpz/Dynamics.hpp
@@ -32,7 +32,6 @@
 #include <vle/vpz/Dynamic.hpp>
 #include <set>
 #include <map>
-#include <vector>
 
 namespace vle {
 namespace vpz {

--- a/src/vle/vpz/Model.cpp
+++ b/src/vle/vpz/Model.cpp
@@ -28,9 +28,6 @@
 #include <vle/vpz/Model.hpp>
 #include <vle/vpz/BaseModel.hpp>
 #include <vle/vpz/AtomicModel.hpp>
-#include <vle/vpz/CoupledModel.hpp>
-#include <algorithm>
-#include <stack>
 
 namespace vle { namespace vpz {
 

--- a/src/vle/vpz/ModelPortList.cpp
+++ b/src/vle/vpz/ModelPortList.cpp
@@ -28,6 +28,7 @@
 #include <vle/vpz/ModelPortList.hpp>
 #include <vle/vpz/BaseModel.hpp>
 #include <vle/utils/Exception.hpp>
+#include <vle/utils/i18n.hpp>
 
 namespace vle { namespace vpz {
 

--- a/src/vle/vpz/Observables.cpp
+++ b/src/vle/vpz/Observables.cpp
@@ -25,7 +25,6 @@
  */
 
 #include <vle/vpz/Observables.hpp>
-#include <vle/utils/Tools.hpp>
 #include <vle/utils/Algo.hpp>
 #include <vle/utils/Exception.hpp>
 #include <iterator>

--- a/src/vle/vpz/SaxParser.hpp
+++ b/src/vle/vpz/SaxParser.hpp
@@ -34,8 +34,7 @@
 #include <vle/vpz/SaxStackVpz.hpp>
 #include <vle/DllDefines.hpp>
 #include <vle/value/Value.hpp>
-#include <vle/value/Set.hpp>
-#include <vle/value/Map.hpp>
+#include <map>
 
 namespace vle { namespace vpz {
 

--- a/src/vle/vpz/SaxStackValue.cpp
+++ b/src/vle/vpz/SaxStackValue.cpp
@@ -26,6 +26,9 @@
 
 
 #include <vle/vpz/SaxStackValue.hpp>
+#include <vle/value/Map.hpp>
+#include <vle/value/Set.hpp>
+
 
 namespace vle { namespace vpz {
 

--- a/src/vle/vpz/SaxStackValue.hpp
+++ b/src/vle/vpz/SaxStackValue.hpp
@@ -30,10 +30,7 @@
 
 #include <stack>
 #include <vle/value/Value.hpp>
-#include <vle/value/Set.hpp>
-#include <vle/value/Map.hpp>
 #include <vle/value/Matrix.hpp>
-#include <vle/value/Tuple.hpp>
 #include <vle/value/Table.hpp>
 #include <vle/DllDefines.hpp>
 

--- a/src/vle/vpz/SaxStackVpz.hpp
+++ b/src/vle/vpz/SaxStackVpz.hpp
@@ -29,7 +29,7 @@
 #define VLE_VPZ_SAXSTACKVPZ_HPP
 
 #include <vle/DllDefines.hpp>
-#include <vle/value/Value.hpp>
+#include <vle/value/Set.hpp>
 #include <libxml/xmlstring.h>
 #include <list>
 


### PR DESCRIPTION
In directories devs, manager, oov, translator, utils, value and vpz, unecessary
includes (and dependecies) are removed.

Tests are performed on vle.examples, vle packages and record tps : No modification of the code (ie no additionnal includes) is necessary. 
