### PR TITLE
gvle: fix the plugin file generation

### DIFF
--- a/src/vle/gvle/AtomicModelBox.cpp
+++ b/src/vle/gvle/AtomicModelBox.cpp
@@ -895,7 +895,7 @@ std::string AtomicModelBox::DynamicTreeView::pathFileSearch(
 	    if (utils::Path::basename(name) == filename
 		and utils::Path::extension(name) == ".cpp") {
 		return Glib::build_filename(
-		  utils::Path::path().getPackageSrcDir(), (*it));
+		  mGVLE->getPackageSrcDir(), (*it));
 	    }
 	}
     }
@@ -906,12 +906,10 @@ void AtomicModelBox::DynamicTreeView::onRowActivated(
     const Gtk::TreeModel::Path& path,
     Gtk::TreeViewColumn* column)
 {
-    if (column
-	and not vle::utils::Path::path().getPackageSourceDir().empty()
-        and utils::Path::exist(vle::utils::Path::path().getPackageSrcDir())) {
+    if (column and
+        utils::Path::exist(mGVLE->getPackageSrcDir())) {
 
         Gtk::TreeRow row = (*mRefListDyn->get_iter(path));
-
 	vpz::Dynamic& dynamic = mDynamics->get(
 	    row.get_value(mColumnsDyn.m_col_name));
 
@@ -922,7 +920,7 @@ void AtomicModelBox::DynamicTreeView::onRowActivated(
 		       searchFile.begin(), tolower);
 
 	std::string newTab = pathFileSearch(
-	    utils::Path::path().getPackageSrcDir(), searchFile);
+	    mGVLE->getPackageSrcDir(), searchFile);
         if (not newTab.empty()) {
             try {
                 std::string pluginname, packagename, conf;
@@ -931,7 +929,6 @@ void AtomicModelBox::DynamicTreeView::onRowActivated(
                 tpl.open(newTab);
 
                 tpl.tag(pluginname, packagename, conf);
-
                 ModelingPluginPtr plugin =
                     mGVLE->pluginFactory().getModelingPlugin(packagename,
                                                              pluginname);
@@ -939,10 +936,8 @@ void AtomicModelBox::DynamicTreeView::onRowActivated(
                 if (plugin->modify(*mAtom, dynamic, *mConditions,
                                    *mObservables, conf, tpl.buffer())) {
                     const std::string& buffer = plugin->source();
-                    std::string filename = utils::Path::path()
-                        .getPackageSrcFile(dynamic.library());
-                    filename += ".cpp";
-
+                    std::string filename = mGVLE->getPackageSrcFile(dynamic.library() +
+                        ".cpp");
                     try {
                         std::ofstream f(filename.c_str());
                         f.exceptions(std::ofstream::failbit |
@@ -1086,8 +1081,8 @@ int AtomicModelBox::DynamicTreeView::execPlugin(
     if (plugin->create(*mAtom, dynamic, *mConditions,
                        *mObservables, classname, namespace_)) {
         const std::string& buffer = plugin->source();
-        std::string filename = utils::Path::path().getPackageSrcFile(classname);
-        filename += ".cpp";
+        std::string filename = mGVLE->getPackageSrcFile(classname + ".cpp");
+        //filename += ".cpp";
 
         try {
             std::ofstream f(filename.c_str());

--- a/src/vle/gvle/DynamicBox.cpp
+++ b/src/vle/gvle/DynamicBox.cpp
@@ -187,8 +187,7 @@ int DynamicBox::execPlugin(const std::string& pluginname,
     if (plugin->create(mAtom, mDynamic, mConditions,
                        mObservables, classname, namespace_)) {
         const std::string& buffer = plugin->source();
-        std::string filename = utils::Path::path().getPackageSrcFile(classname);
-        filename += ".cpp";
+        std::string filename = mGVLE->getPackageSrcFile(classname + ".cpp");
 
         try {
             std::ofstream f(filename.c_str());

--- a/src/vle/gvle/GVLE.cpp
+++ b/src/vle/gvle/GVLE.cpp
@@ -675,6 +675,7 @@ void GVLE::onOpenProject()
 
             if (not basename.empty()) {
                 if (g_chdir(dirname.c_str()) == 0) {
+                    mPkgDirName = utils::Path::path().buildDirname(dirname, basename);
                     onCloseProject();
                     utils::Package::package().select(basename);
                     mPluginFactory.update();

--- a/src/vle/gvle/GVLE.hpp
+++ b/src/vle/gvle/GVLE.hpp
@@ -39,6 +39,7 @@
 #include <vle/gvle/QuitBox.hpp>
 #include <vle/gvle/SaveVpzBox.hpp>
 #include <vle/gvle/SpawnPool.hpp>
+#include <vle/utils/Path.hpp>
 #include <vle/value/Value.hpp>
 #include <gtkmm/window.h>
 #include <gtkmm/textview.h>
@@ -133,6 +134,19 @@ public:
      * @return a boolean
      */
     bool on_timeout();
+
+    /**
+     * @brief Get a complete source file name.
+     * @return A string
+     */
+    std::string getPackageSrcFile(const std::string& file) const
+    { return utils::Path::path().buildFilename(mPkgDirName, "src", file); }
+    /**
+     * @brief Get a complete source dir  name.
+     * @return A string
+     */
+    std::string getPackageSrcDir() const
+    { return utils::Path::path().buildDirname(mPkgDirName, "src"); }
 
     /**
      * @brief Get a constant reference to the PluginFactory.
@@ -894,6 +908,7 @@ private:
     /* class members */
     Modeling*                       mModeling;
     std::string                     mCurrentClass;
+    std::string                     mPkgDirName;
     ListView                        mListView;
     ButtonType                      mCurrentButton;
     CutCopyPaste                    mCutCopyPaste;


### PR DESCRIPTION
gvle assume that the folder loaded is a project working directory. It
does keep it as a member field. And when a plugin does want to save a
generated file, the expected place is the "src" subdirectory of the
project source directory (Closes #63,#62).
