### PR TITLE
utils: update the package API

### DIFF
--- a/src/vle/devs/Dynamics.cpp
+++ b/src/vle/devs/Dynamics.cpp
@@ -91,115 +91,133 @@ ExternalEvent* Dynamics::buildEventWithAString(
 
 std::string Dynamics::getPackageDir() const
 {
-    if (utils::Package::package().name() == *m_packageid) {
-        return utils::Path::path().getPackageBinaryDir();
+    vle::utils::Package pkg(*m_packageid);
+    if (pkg.existsBinary()) {
+        return pkg.getDir(vle::utils::PKG_BINARY);
     } else {
-        return utils::Path::path().getExternalPackageDir(*m_packageid);
+        throw vle::utils::FileError(vle::fmt(_("Package '%1%' is not "
+                "installed")) % *m_packageid);
     }
 }
 
 std::string Dynamics::getPackageSimulatorDir() const
 {
-    if (utils::Package::package().name() == *m_packageid) {
-        return utils::Path::path().getPackagePluginSimulatorDir();
+    vle::utils::Package pkg(*m_packageid);
+    if (pkg.existsBinary()) {
+        return pkg.getPluginSimulatorDir(vle::utils::PKG_BINARY);
     } else {
-        return utils::Path::path().getExternalPackagePluginSimulatorDir(
-            *m_packageid);
+        throw vle::utils::FileError(vle::fmt(_("Package '%1%' is not "
+                "installed")) % *m_packageid);
     }
 }
 
 std::string Dynamics::getPackageSrcDir() const
 {
-    if (utils::Package::package().name() == *m_packageid) {
-        return utils::Path::path().getPackageSrcDir();
+    vle::utils::Package pkg(*m_packageid);
+    if (pkg.existsBinary()) {
+        return pkg.getSrcDir(vle::utils::PKG_BINARY);
     } else {
-        return utils::Path::path().getExternalPackageSrcDir(*m_packageid);
+        throw vle::utils::FileError(vle::fmt(_("Package '%1%' is not "
+                "installed")) % *m_packageid);
     }
 }
 
 std::string Dynamics::getPackageDataDir() const
 {
-    if (utils::Package::package().name() == *m_packageid) {
-        return utils::Path::path().getPackageDataDir();
+    vle::utils::Package pkg(*m_packageid);
+    if (pkg.existsBinary()) {
+        return pkg.getDataDir(vle::utils::PKG_BINARY);
     } else {
-        return utils::Path::path().getExternalPackageDataDir(*m_packageid);
+        throw vle::utils::FileError(vle::fmt(_("Package '%1%' is not "
+                "installed")) % *m_packageid);
     }
 }
 
 std::string Dynamics::getPackageDocDir() const
 {
-    if (utils::Package::package().name() == *m_packageid) {
-        return utils::Path::path().getPackageDocDir();
+    vle::utils::Package pkg(*m_packageid);
+    if (pkg.existsBinary()) {
+        return pkg.getDocDir(vle::utils::PKG_BINARY);
     } else {
-        return utils::Path::path().getExternalPackageDocDir(*m_packageid);
+        throw vle::utils::FileError(vle::fmt(_("Package '%1%' is not "
+                "installed")) % *m_packageid);
     }
 }
 
 std::string Dynamics::getPackageExpDir() const
 {
-    if (utils::Package::package().name() == *m_packageid) {
-        return utils::Path::path().getPackageExpDir();
+    vle::utils::Package pkg(*m_packageid);
+    if (pkg.existsBinary()) {
+        return pkg.getExpDir(vle::utils::PKG_BINARY);
     } else {
-        return utils::Path::path().getExternalPackageExpDir(*m_packageid);
+        throw vle::utils::FileError(vle::fmt(_("Package '%1%' is not "
+                "installed")) % *m_packageid);
     }
 }
 
 std::string Dynamics::getPackageFile(const std::string& name) const
 {
-    if (utils::Package::package().name() == *m_packageid) {
-        return utils::Path::path().getPackageFile(name);
+    vle::utils::Package pkg(*m_packageid);
+    if (pkg.existsBinary()) {
+        return pkg.getFile(name, vle::utils::PKG_BINARY);
     } else {
-        return utils::Path::path().getExternalPackageFile(*m_packageid, name);
+        throw vle::utils::FileError(vle::fmt(_("Package '%1%' is not "
+                "installed")) % *m_packageid);
     }
 }
 
 std::string Dynamics::getPackageLibFile(const std::string& name) const
 {
-    if (utils::Package::package().name() == *m_packageid) {
-        return utils::Path::path().getPackageLibFile(name);
+    vle::utils::Package pkg(*m_packageid);
+    if (pkg.existsBinary()) {
+        return pkg.getLibFile(name, vle::utils::PKG_BINARY);
     } else {
-        return utils::Path::path().getExternalPackageLibFile(*m_packageid,
-                                                             name);
+        throw vle::utils::FileError(vle::fmt(_("Package '%1%' is not "
+                "installed")) % *m_packageid);
     }
 }
 
 std::string Dynamics::getPackageSrcFile(const std::string& name) const
 {
-    if (utils::Package::package().name() == *m_packageid) {
-        return utils::Path::path().getPackageSrcFile(name);
+    vle::utils::Package pkg(*m_packageid);
+    if (pkg.existsBinary()) {
+        return pkg.getSrcFile(name, vle::utils::PKG_BINARY);
     } else {
-        return utils::Path::path().getExternalPackageSrcFile(*m_packageid,
-                                                             name);
+        throw vle::utils::FileError(vle::fmt(_("Package '%1%' is not "
+                "installed")) % *m_packageid);
     }
 }
 
 std::string Dynamics::getPackageDataFile(const std::string& name) const
 {
-    if (utils::Package::package().name() == *m_packageid) {
-        return utils::Path::path().getPackageDataFile(name);
+    vle::utils::Package pkg(*m_packageid);
+    if (pkg.existsBinary()) {
+        return pkg.getDataFile(name, vle::utils::PKG_BINARY);
     } else {
-        return utils::Path::path().getExternalPackageDataFile(*m_packageid,
-                                                              name);
+        throw vle::utils::FileError(vle::fmt(_("Package '%1%' is not "
+                "installed")) % *m_packageid);
     }
 }
 
 std::string Dynamics::getPackageDocFile(const std::string& name) const
 {
-    if (utils::Package::package().name() == *m_packageid) {
-        return utils::Path::path().getPackageDocFile(name);
+    vle::utils::Package pkg(*m_packageid);
+    if (pkg.existsBinary()) {
+        return pkg.getDocFile(name, vle::utils::PKG_BINARY);
     } else {
-        return utils::Path::path().getExternalPackageDocFile(*m_packageid,
-                                                             name);
+        throw vle::utils::FileError(vle::fmt(_("Package '%1%' is not "
+                "installed")) % *m_packageid);
     }
 }
 
 std::string Dynamics::getPackageExpFile(const std::string& name) const
 {
-    if (utils::Package::package().name() == *m_packageid) {
-        return utils::Path::path().getPackageExpFile(name);
+    vle::utils::Package pkg(*m_packageid);
+    if (pkg.existsBinary()) {
+        return pkg.getExpFile(name, vle::utils::PKG_BINARY);
     } else {
-        return utils::Path::path().getExternalPackageExpFile(*m_packageid,
-                                                             name);
+        throw vle::utils::FileError(vle::fmt(_("Package '%1%' is not "
+                "installed")) % *m_packageid);
     }
 }
 

--- a/src/vle/devs/ModelFactory.cpp
+++ b/src/vle/devs/ModelFactory.cpp
@@ -230,9 +230,10 @@ static devs::Dynamics* buildNewDynamicsWrapper(
     fctdw fct = utils::functionCast < fctdw >(symbol);
 
     try {
+        utils::PackageTable pkg_table;
         return fct(DynamicsWrapperInit(
                 *atom->getStructure(),
-                utils::Package::package().getId(dyn.package()),
+                pkg_table.get(dyn.package()),
                 dyn.library()), events);
     } catch(const std::exception& e) {
         throw utils::ModellingError(
@@ -256,9 +257,10 @@ static devs::Dynamics* buildNewDynamics(
     fctdyn fct = utils::functionCast < fctdyn >(symbol);
 
     try {
+        utils::PackageTable pkg_table;
         return fct(DynamicsInit(
                 *atom->getStructure(),
-                utils::Package::package().getId(dyn.package())),
+                pkg_table.get(dyn.package())),
             events);
     } catch(const std::exception& e) {
         throw utils::ModellingError(
@@ -282,9 +284,10 @@ static devs::Dynamics* buildNewExecutive(
     fctexe fct = utils::functionCast < fctexe >(symbol);
 
     try {
+        utils::PackageTable pkg_table;
         return fct(ExecutiveInit(
                 *atom->getStructure(),
-                utils::Package::package().getId(dyn.package()),
+                pkg_table.get(dyn.package()),
                 coordinator), events);
     } catch(const std::exception& e) {
         throw utils::ModellingError(

--- a/src/vle/gvle/AtomicModelBox.cpp
+++ b/src/vle/gvle/AtomicModelBox.cpp
@@ -931,7 +931,8 @@ void AtomicModelBox::DynamicTreeView::onRowActivated(
                 tpl.tag(pluginname, packagename, conf);
                 ModelingPluginPtr plugin =
                     mGVLE->pluginFactory().getModelingPlugin(packagename,
-                                                             pluginname);
+                                      pluginname,
+                                      mGVLE->currentPackage().name());
 
                 if (plugin->modify(*mAtom, dynamic, *mConditions,
                                    *mObservables, conf, tpl.buffer())) {
@@ -1045,7 +1046,7 @@ void AtomicModelBox::DynamicTreeView::onNewLibrary()
             OpenModelingPluginBox box1(mXml, mGVLE);
 
             if (box1.run() == Gtk::RESPONSE_OK) {
-                NewDynamicsBox box2(mXml);
+                NewDynamicsBox box2(mXml, mGVLE->currentPackage());
 
                 if (box2.run() == Gtk::RESPONSE_OK and
                     not box2.getClassName().empty() and
@@ -1056,8 +1057,7 @@ void AtomicModelBox::DynamicTreeView::onNewLibrary()
                             box2.getClassName(),
                             box2.getNamespace()) == Gtk::RESPONSE_OK) {
                         dyn.setLibrary(box2.getClassName());
-                        dyn.setPackage(
-                            vle::utils::Package::package().name());
+                        dyn.setPackage(mGVLE->currentPackage().name());
                         mDynamics->add(dyn);
                         build();
 
@@ -1076,7 +1076,8 @@ int AtomicModelBox::DynamicTreeView::execPlugin(
     const std::string& namespace_)
 {
     ModelingPluginPtr plugin =
-        mGVLE->pluginFactory().getModelingPlugin(pluginname);
+        mGVLE->pluginFactory().getModelingPlugin(pluginname,
+                mGVLE->currentPackage().name());
 
     if (plugin->create(*mAtom, dynamic, *mConditions,
                        *mObservables, classname, namespace_)) {

--- a/src/vle/gvle/ConditionsBox.cpp
+++ b/src/vle/gvle/ConditionsBox.cpp
@@ -245,7 +245,8 @@ void ConditionsBox::ConditionsTreeView::onEdit(std::string pluginName)
 
         try {
             PluginFactory& plf = mParent->getGVLE()->pluginFactory();
-            ModelingPluginPtr plugin = plf.getModelingPlugin(pluginName);
+            ModelingPluginPtr plugin = plf.getModelingPlugin(pluginName,
+                    mParent->getGVLE()->currentPackage().name());
             vpz::Condition& cond = mConditions->get(conditionName);
             plugin->start(cond);
 
@@ -547,7 +548,8 @@ void ConditionsBox::PortsTreeView::onEdit(std::string pluginName)
 	PluginFactory& plf = mParent->getGVLE()->pluginFactory();
 
 	try {
-	    ModelingPluginPtr plugin = plf.getModelingPlugin(pluginName);
+	    ModelingPluginPtr plugin = plf.getModelingPlugin(pluginName,
+	            mParent->getGVLE()->currentPackage().name());
 	    plugin->start(*mCondition, name);
 	    mParent->buildTreeValues(mCondition->name(), name);
 	} catch(const std::exception& /*e*/) {

--- a/src/vle/gvle/DynamicBox.cpp
+++ b/src/vle/gvle/DynamicBox.cpp
@@ -122,7 +122,7 @@ void DynamicBox::makeComboPackage()
 {
     mComboPackage->clear();
 
-    utils::PathList paths = utils::Path::path().getInstalledPackages();
+    utils::PathList paths = utils::Path::path().getBinaryPackages();
 
     std::sort(paths.begin(), paths.end());
     for (utils::PathList::const_iterator i = paths.begin(), e = paths.end();
@@ -161,7 +161,7 @@ void DynamicBox::onNewLibrary()
     OpenModelingPluginBox box(mXml, mGVLE);
 
     if (box.run() == Gtk::RESPONSE_OK) {
-        NewDynamicsBox box2(mXml);
+        NewDynamicsBox box2(mXml, mGVLE->currentPackage());
 
         if (box2.run() == Gtk::RESPONSE_OK and
             not box2.getClassName().empty() and
@@ -182,8 +182,8 @@ int DynamicBox::execPlugin(const std::string& pluginname,
                            const std::string& namespace_)
 {
     ModelingPluginPtr plugin =
-        mGVLE->pluginFactory().getModelingPlugin(pluginname);
-
+        mGVLE->pluginFactory().getModelingPlugin(pluginname,
+                mGVLE->currentPackage().name());
     if (plugin->create(mAtom, mDynamic, mConditions,
                        mObservables, classname, namespace_)) {
         const std::string& buffer = plugin->source();

--- a/src/vle/gvle/DynamicsBox.cpp
+++ b/src/vle/gvle/DynamicsBox.cpp
@@ -221,7 +221,7 @@ void DynamicsBox::initDynamicsColumnLibrary()
 
 void DynamicsBox::fillLibrariesListStore()
 {
-    utils::PathList paths = utils::Path::path().getInstalledPackages();
+    utils::PathList paths = utils::Path::path().getBinaryPackages();
     std::sort(paths.begin(), paths.end());
     for (utils::PathList::const_iterator i = paths.begin(), e = paths.end();
          i != e; ++i) {
@@ -249,7 +249,7 @@ void DynamicsBox::fillDynamics()
 
     mPackagesListStore = Gtk::ListStore::create(mPackageColumns);
 
-    utils::PathList paths = utils::Path::path().getInstalledPackages();
+    utils::PathList paths = utils::Path::path().getBinaryPackages();
     std::sort(paths.begin(), paths.end());
     for (utils::PathList::const_iterator i = paths.begin(), e = paths.end();
          i != e; ++i) {

--- a/src/vle/gvle/GVLE.hpp
+++ b/src/vle/gvle/GVLE.hpp
@@ -39,7 +39,7 @@
 #include <vle/gvle/QuitBox.hpp>
 #include <vle/gvle/SaveVpzBox.hpp>
 #include <vle/gvle/SpawnPool.hpp>
-#include <vle/utils/Path.hpp>
+#include <vle/utils/Package.hpp>
 #include <vle/value/Value.hpp>
 #include <gtkmm/window.h>
 #include <gtkmm/textview.h>
@@ -140,13 +140,15 @@ public:
      * @return A string
      */
     std::string getPackageSrcFile(const std::string& file) const
-    { return utils::Path::path().buildFilename(mPkgDirName, "src", file); }
+    { return utils::Path::path().buildFilename(
+            mCurrPackage.getDir(vle::utils::PKG_SOURCE), "src", file); }
     /**
      * @brief Get a complete source dir  name.
      * @return A string
      */
     std::string getPackageSrcDir() const
-    { return utils::Path::path().buildDirname(mPkgDirName, "src"); }
+    { return utils::Path::path().buildDirname(
+            mCurrPackage.getDir(vle::utils::PKG_SOURCE), "src"); }
 
     /**
      * @brief Get a constant reference to the PluginFactory.
@@ -722,6 +724,11 @@ public:
      */
     void packageProject();
 
+    inline vle::utils::Package& currentPackage()
+    {
+        return mCurrPackage;
+    }
+
 
 
     /********************************************************************
@@ -914,11 +921,9 @@ private:
     /* class members */
     Modeling*                       mModeling;
     std::string                     mCurrentClass;
-    std::string                     mPkgDirName;
     ListView                        mListView;
     ButtonType                      mCurrentButton;
     CutCopyPaste                    mCutCopyPaste;
-    std::string                     mPackage;
     int                             mCurrentTab;
 
     /* File chooser */
@@ -939,6 +944,7 @@ private:
     ModelTreeBox*                   mModelTreeBox;
     ModelClassBox*                  mModelClassBox;
     QuitBox*                        mQuitBox;
+    utils::Package                  mCurrPackage;
 
     PluginFactory                   mPluginFactory;
 

--- a/src/vle/gvle/LaunchSimulationBox.hpp
+++ b/src/vle/gvle/LaunchSimulationBox.hpp
@@ -29,6 +29,7 @@
 #define VLE_GVLE_LAUNCHSIMULATIONBOX_HPP
 
 #include <vle/utils/ModuleManager.hpp>
+#include <vle/utils/Package.hpp>
 #include <gtkmm/builder.h>
 #include <gtkmm/dialog.h>
 #include <gtkmm/radiobutton.h>
@@ -49,7 +50,7 @@ class LaunchSimulationBox
 {
 public:
     LaunchSimulationBox(const Glib::RefPtr < Gtk::Builder >& xml,
-			const vpz::Vpz& file);
+			const vpz::Vpz& file, const vle::utils::Package& curr_pack);
 
     ~LaunchSimulationBox();
 
@@ -92,6 +93,8 @@ private:
     Glib::Thread* mThread;
     Glib::Mutex   mMutex;
     bool          mThreadRun;
+
+    const vle::utils::Package&      mCurrPackage;
 
     /* accessors to the protected variables */
     void setState(State state);

--- a/src/vle/gvle/ModelingPlugin.hpp
+++ b/src/vle/gvle/ModelingPlugin.hpp
@@ -36,24 +36,25 @@
 #include <vector>
 #include <boost/shared_ptr.hpp>
 
-#define DECLARE_GVLE_MODELINGPLUGIN(x)                          \
-    extern "C" {                                                \
-        GVLE_MODULE vle::gvle::ModelingPlugin*                  \
-        vle_make_new_gvle_modeling(const std::string& package,  \
-                                   const std::string& library)  \
-        {                                                       \
-            return new x(package, library);                     \
-        }                                                       \
-                                                                \
-        GVLE_MODULE void                                        \
-        vle_api_level(vle::uint32_t* major,                     \
-                      vle::uint32_t* minor,                     \
-                      vle::uint32_t* patch)                     \
-        {                                                       \
-            *major = VLE_MAJOR_VERSION;                         \
-            *minor = VLE_MINOR_VERSION;                         \
-            *patch = VLE_PATCH_VERSION;                         \
-        }                                                       \
+#define DECLARE_GVLE_MODELINGPLUGIN(x)                              \
+    extern "C" {                                                    \
+        GVLE_MODULE vle::gvle::ModelingPlugin*                      \
+        vle_make_new_gvle_modeling(const std::string& package,      \
+                                   const std::string& library,      \
+                                   const std::string& currPackage)  \
+        {                                                           \
+            return new x(package, library, currPackage);            \
+        }                                                           \
+                                                                    \
+        GVLE_MODULE void                                            \
+        vle_api_level(vle::uint32_t* major,                         \
+                      vle::uint32_t* minor,                         \
+                      vle::uint32_t* patch)                         \
+        {                                                           \
+            *major = VLE_MAJOR_VERSION;                             \
+            *minor = VLE_MINOR_VERSION;                             \
+            *patch = VLE_PATCH_VERSION;                             \
+        }                                                           \
     }
 
 namespace vle { namespace gvle {
@@ -73,12 +74,16 @@ public:
     /**
      * @brief Build a new ModelingPlugin.
      *
-     * @param package The name of the package.
+     * @param package The name of the package containing the plugin
      * @param library The name of the plug-in.
+     * @param curr_package the name of the current package
+     *
      */
-    ModelingPlugin(const std::string& package, const std::string& library)
-        : mPackage(package), mLibrary(library)
-    {}
+    ModelingPlugin(const std::string& package, const std::string& library,
+            const std::string& curr_package)
+        : mPackage(package), mLibrary(library), mCurrPackage(curr_package)
+    {
+    }
 
     virtual ~ModelingPlugin()
     {}
@@ -164,9 +169,13 @@ public:
 
     const std::string& getLibrary() const { return mLibrary; }
 
+    const std::string& getCurrPackage() const { return mCurrPackage; }
+
 protected:
     std::string mPackage;
     std::string mLibrary;
+    std::string mCurrPackage;
+
     Source mSource;
 
 private:
@@ -178,7 +187,8 @@ private:
 
 typedef boost::shared_ptr < ModelingPlugin > ModelingPluginPtr;
 typedef ModelingPlugin* (*GvleModelingPluginSlot)(const std::string&,
-						  const std::string&);
+                                                  const std::string&,
+                                                  const std::string&);
 
 }} // namespace vle gvle
 

--- a/src/vle/gvle/NewDynamicsBox.cpp
+++ b/src/vle/gvle/NewDynamicsBox.cpp
@@ -26,12 +26,12 @@
 
 
 #include <vle/gvle/NewDynamicsBox.hpp>
-#include <vle/utils/Package.hpp>
 
 namespace vle { namespace gvle {
 
-NewDynamicsBox::NewDynamicsBox(const Glib::RefPtr < Gtk::Builder >& xml):
-    mXml(xml)
+NewDynamicsBox::NewDynamicsBox(const Glib::RefPtr < Gtk::Builder >& xml,
+        const vle::utils::Package& curr_pack):
+    mXml(xml), mCurrPackage(curr_pack)
 {
     xml->get_widget("DialogNewDynamics", mDialog);
     xml->get_widget("EntryClassName", mEntryClassName);
@@ -68,7 +68,7 @@ void NewDynamicsBox::onCancel()
 
 int NewDynamicsBox::run()
 {
-    mEntryNamespace->set_text(utils::Package::package().name());
+    mEntryNamespace->set_text(mCurrPackage.name());
     mDialog->show_all();
     return mDialog->run();
 }

--- a/src/vle/gvle/NewDynamicsBox.hpp
+++ b/src/vle/gvle/NewDynamicsBox.hpp
@@ -32,13 +32,15 @@
 #include <gtkmm/dialog.h>
 #include <gtkmm/entry.h>
 #include <gtkmm/button.h>
+#include <vle/utils/Package.hpp>
 
 namespace vle { namespace gvle {
 
 class NewDynamicsBox
 {
 public:
-    NewDynamicsBox(const Glib::RefPtr < Gtk::Builder >& xml);
+    NewDynamicsBox(const Glib::RefPtr < Gtk::Builder >& xml,
+            const vle::utils::Package& curr_pack);
     ~NewDynamicsBox();
 
     std::string getClassName() const
@@ -64,6 +66,8 @@ private:
     Gtk::Button*                    mButtonCancel;
 
     std::list < sigc::connection >      mList;
+
+    const vle::utils::Package&      mCurrPackage;
 };
 
 }} // namespace vle gvle

--- a/src/vle/gvle/NewProjectBox.cpp
+++ b/src/vle/gvle/NewProjectBox.cpp
@@ -63,16 +63,16 @@ void NewProjectBox::show()
 void NewProjectBox::apply()
 {
     if (not mEntryName->get_text().empty()) {
-	if (not exist(mEntryName->get_text())) {
-	    mGVLE->getEditor()->closeAllTab();
-	    mModeling->clearModeling();
-            mGVLE->setTitle(mModeling->getFileName());
-            utils::Package::package().select(mEntryName->get_text());
-            mGVLE->pluginFactory().update();
-	    vle::utils::Package::package().create();
-	    mGVLE->buildPackageHierarchy();
-            mGVLE->getMenu()->onOpenProject();
-	} else {
+    if (not exist(mEntryName->get_text())) {
+        mGVLE->getEditor()->closeAllTab();
+        mModeling->clearModeling();
+        mGVLE->setTitle(mModeling->getFileName());
+        mGVLE->currentPackage().select(mEntryName->get_text());
+        mGVLE->pluginFactory().update();
+        mGVLE->currentPackage().create();
+        mGVLE->buildPackageHierarchy();
+        mGVLE->getMenu()->onOpenProject();
+    } else {
             Error(fmt(_("The project `%1%' already exists in VLE home "
                          "directory")) % mEntryName->get_text().raw());
 	}
@@ -81,13 +81,13 @@ void NewProjectBox::apply()
 
 bool NewProjectBox::exist(const std::string& name)
 {
-    utils::PathList list = utils::Path::path().getInstalledPackages();
+    utils::PathList list = utils::Path::path().getBinaryPackages();
     utils::PathList::const_iterator it = list.begin();
     while (it != list.end()) {
-	if (utils::Path::basename(*it) == name) {
-	    return true;
-	}
-	++it;
+        if (utils::Path::basename(*it) == name) {
+            return true;
+        }
+        ++it;
     }
     return false;
 }

--- a/src/vle/gvle/OpenPackageBox.cpp
+++ b/src/vle/gvle/OpenPackageBox.cpp
@@ -27,13 +27,13 @@
 
 #include <vle/gvle/OpenPackageBox.hpp>
 #include <vle/gvle/Message.hpp>
-#include <vle/utils/Package.hpp>
 #include <vle/utils/Path.hpp>
 
 namespace vle { namespace gvle {
 
-OpenPackageBox::OpenPackageBox(const Glib::RefPtr < Gtk::Builder >& xml)
-    : mXml(xml)
+OpenPackageBox::OpenPackageBox(const Glib::RefPtr < Gtk::Builder >& xml,
+        vle::utils::Package& curr_pack)
+    : mXml(xml), mCurrentPackage(curr_pack)
 {
     xml->get_widget("DialogPackage", mDialog);
     xml->get_widget("TreeViewPackage", mTreeView);
@@ -97,7 +97,7 @@ void OpenPackageBox::build()
     mTreeModel->clear();
     mName.clear();
 
-    utils::PathList list = utils::Path::path().getInstalledPackages();
+    utils::PathList list = utils::Path::path().getBinaryPackages();
 
     std::sort(list.begin(), list.end());
     for (utils::PathList::const_iterator it = list.begin();
@@ -154,7 +154,7 @@ void OpenPackageBox::onRemoveCallBack(const Gtk::TreeModel::iterator& it)
 
     if (row) {
         Glib::ustring package = row[mColumns.mName];
-        utils::Package::package().removePackage(package.raw());
+        mCurrentPackage.remove(package.raw(), vle::utils::PKG_SOURCE);
     }
 }
 

--- a/src/vle/gvle/OpenPackageBox.hpp
+++ b/src/vle/gvle/OpenPackageBox.hpp
@@ -32,6 +32,7 @@
 #include <gtkmm/dialog.h>
 #include <gtkmm/treestore.h>
 #include <gtkmm/builder.h>
+#include <vle/utils/Package.hpp>
 
 namespace vle { namespace gvle {
 
@@ -43,7 +44,8 @@ namespace vle { namespace gvle {
 class OpenPackageBox
 {
 public:
-    OpenPackageBox(const Glib::RefPtr < Gtk::Builder >& xml);
+    OpenPackageBox(const Glib::RefPtr < Gtk::Builder >& xml,
+            vle::utils::Package& curr_pack);
 
     virtual ~OpenPackageBox();
 
@@ -80,6 +82,7 @@ private:
     Glib::RefPtr < Gtk::TreeSelection > mTreeSelection;
 
     std::string                     mName;
+    vle::utils::Package&            mCurrentPackage;
 
     void build();
     void onCancel();

--- a/src/vle/gvle/OpenVpzBox.cpp
+++ b/src/vle/gvle/OpenVpzBox.cpp
@@ -70,15 +70,16 @@ void OpenVpzBox::build()
 {
     mRefTreeVpz->clear();
 
-    utils::PathList list = utils::Path::path().getInstalledExperiments();
+    utils::PathList list = mGVLE->currentPackage().getExperiments(
+            vle::utils::PKG_SOURCE);
     utils::PathList::const_iterator it = list.begin();
     while (it != list.end()) {
-	Gtk::TreeModel::Row row(*mRefTreeVpz->append());
-        size_t begin = utils::Path::path().getPackageExpDir().size() + 1;
+        Gtk::TreeModel::Row row(*mRefTreeVpz->append());
+        size_t begin = mGVLE->currentPackage().getDir(
+                vle::utils::PKG_SOURCE).size() + 1;
         std::string name(*it, begin, it->size() - begin - 4);
-
-	row[mColumns.mName] = name;
-	++it;
+        row[mColumns.mName] = name;
+        ++it;
     }
 }
 
@@ -95,19 +96,20 @@ OpenVpzBox::~OpenVpzBox()
 
 void OpenVpzBox::onApply()
 {
-    Glib::RefPtr<Gtk::TreeView::Selection> refSelection
-	= mTreeView->get_selection();
+    Glib::RefPtr<Gtk::TreeView::Selection> refSelection =
+            mTreeView->get_selection();
 
     if (refSelection) {
-	Gtk::TreeModel::iterator iter = refSelection->get_selected();
+        Gtk::TreeModel::iterator iter = refSelection->get_selected();
 
-	if (iter) {
-	    Gtk::TreeModel::Row row = *iter;
-	    std::string name = row.get_value(mColumns.mName);
-	    std::string pathFile = Glib::build_filename(
-		utils::Path::path().getPackageExpDir(), name);
+        if (iter) {
+            Gtk::TreeModel::Row row = *iter;
+            std::string name = row.get_value(mColumns.mName);
+            std::string pathFile = Glib::build_filename(
+                    mGVLE->currentPackage().getDir(
+                            vle::utils::PKG_SOURCE), name);
 
-	    pathFile += ".vpz";
+            pathFile += ".vpz";
 
             mGVLE->parseXML(pathFile);
             mGVLE->getEditor()->openTabVpz(mModeling->getFileName(),

--- a/src/vle/gvle/PluginFactory.cpp
+++ b/src/vle/gvle/PluginFactory.cpp
@@ -113,8 +113,10 @@ GlobalPluginPtr PluginFactory::getGlobalPlugin(const std::string& pluginname,
     return getGlobalPlugin(package, library, gvle);
 }
 
-ModelingPluginPtr PluginFactory::getModelingPlugin(const std::string& package,
-                                                   const std::string& library)
+ModelingPluginPtr PluginFactory::getModelingPlugin(
+        const std::string& package,
+        const std::string& library,
+        const std::string& curr_package)
 {
     ModelingPluginPtr modelingPluginPtr;
     ModelingPluginList::iterator it;
@@ -133,20 +135,23 @@ ModelingPluginPtr PluginFactory::getModelingPlugin(const std::string& package,
 
         fct = utils::functionCast < GvleModelingPluginSlot >(symbol);
 
-        modelingPluginPtr = ModelingPluginPtr(fct(package, library));
+        modelingPluginPtr = ModelingPluginPtr(
+                fct(package, library, curr_package));
         mPimpl->mModelingPluginList[symbol] = modelingPluginPtr;
     }
 
     return modelingPluginPtr;
 }
 
-ModelingPluginPtr PluginFactory::getModelingPlugin(const std::string& pluginname)
+ModelingPluginPtr PluginFactory::getModelingPlugin(
+        const std::string& pluginname,
+        const std::string& curr_package)
 {
     std::string package, library;
 
     buildPackageLibraryNames(pluginname, &package, &library);
 
-    return getModelingPlugin(package, library);
+    return getModelingPlugin(package, library, curr_package);
 }
 
 OutputPluginPtr PluginFactory::getOutputPlugin(const std::string& package,

--- a/src/vle/gvle/PluginFactory.hpp
+++ b/src/vle/gvle/PluginFactory.hpp
@@ -70,9 +70,11 @@ public:
 				    GVLE* gvle);
 
     ModelingPluginPtr getModelingPlugin(const std::string& package,
-                                        const std::string& library);
+                                        const std::string& library,
+                                        const std::string& curr_package);
 
-    ModelingPluginPtr getModelingPlugin(const std::string& pluginname);
+    ModelingPluginPtr getModelingPlugin(const std::string& pluginname,
+                                        const std::string& curr_package);
 
     OutputPluginPtr getOutputPlugin(const std::string& package,
                                     const std::string& library);

--- a/src/vle/gvle/SaveVpzBox.cpp
+++ b/src/vle/gvle/SaveVpzBox.cpp
@@ -71,23 +71,25 @@ void SaveVpzBox::show()
 void SaveVpzBox::onApply()
 {
     if (not mEntryName->get_text().empty()) {
-	if (not exist(mEntryName->get_text()) or
-	    gvle::Question(_("Do you want to replace the file ") +
-		    static_cast<std::string>(mEntryName->get_text()))) {
-	    const Modeling* modeling = (const Modeling*)(mModeling);
-	    std::string fileName = mEntryName->get_text();
-	    vpz::Vpz::fixExtension(fileName);
-	    std::string pathFile = Glib::build_filename(
-		utils::Path::path().getPackageExpDir(), fileName);
-	    Editor::Documents::const_iterator it = mGVLE->getEditor()
-		->getDocuments().find(modeling->getFileName());
-	    mModeling->saveXML(pathFile);
+        if (not exist(mEntryName->get_text()) or
+                gvle::Question(_("Do you want to replace the file ") +
+                        static_cast<std::string>(mEntryName->get_text()))) {
+            const Modeling* modeling = (const Modeling*)(mModeling);
+            std::string fileName = mEntryName->get_text();
+            vpz::Vpz::fixExtension(fileName);
+            std::string pathFile = Glib::build_filename(
+                    mGVLE->currentPackage().getExpDir(
+                            vle::utils::PKG_SOURCE), fileName);
+            Editor::Documents::const_iterator it =
+                    mGVLE->getEditor()->getDocuments().find(
+                            modeling->getFileName());
+            mModeling->saveXML(pathFile);
             mGVLE->setTitle(modeling->getFileName());
-	    if (it != mGVLE->getEditor()->getDocuments().end()) {
-		it->second->setTitle(pathFile, mModeling->getTopModel(), false);
-	    }
-	    mDialog->hide_all();
-	}
+            if (it != mGVLE->getEditor()->getDocuments().end()) {
+                it->second->setTitle(pathFile, mModeling->getTopModel(), false);
+            }
+            mDialog->hide_all();
+        }
     }
 }
 
@@ -98,13 +100,13 @@ void SaveVpzBox::onCancel()
 
 bool SaveVpzBox::exist(std::string name)
 {
-    utils::PathList list = utils::Path::path().getInstalledExperiments();
+    utils::PathList list =  mGVLE->currentPackage().getExperiments();
     utils::PathList::const_iterator it = list.begin();
     while (it != list.end()) {
-	if (utils::Path::basename(*it) == name) {
-	    return true;
-	}
-	++it;
+        if (utils::Path::basename(*it) == name) {
+            return true;
+        }
+        ++it;
     }
     return false;
 }

--- a/src/vle/utils/ModuleManager.cpp
+++ b/src/vle/utils/ModuleManager.cpp
@@ -29,7 +29,7 @@
 #include <vle/utils/Exception.hpp>
 #include <vle/utils/i18n.hpp>
 #include <vle/utils/Algo.hpp>
-#include <vle/utils/Path.hpp>
+#include <vle/utils/Package.hpp>
 #include <vle/utils/Trace.hpp>
 #include <vle/version.hpp>
 #include <boost/unordered_map.hpp>
@@ -643,7 +643,7 @@ void ModuleManager::browse()
 {
     boost::mutex::scoped_lock lock(mPimpl->mMutex);
 
-    fs::path packages = utils::Path::path().getPackagesDir();
+    fs::path packages = utils::Path::path().getBinaryPackagesDir();
 
     fs::path pathsim = "plugins/simulator";
     fs::path pathoov = "plugins/output";
@@ -720,7 +720,7 @@ void ModuleManager::browse(ModuleType type)
 {
     boost::mutex::scoped_lock lock(mPimpl->mMutex);
 
-    fs::path packages = utils::Path::path().getPackagesDir();
+    fs::path packages = utils::Path::path().getBinaryPackagesDir();
 
     fs::path pathtype;
 
@@ -766,7 +766,7 @@ void ModuleManager::browse(const std::string& package)
 {
     boost::mutex::scoped_lock lock(mPimpl->mMutex);
 
-    fs::path pkg = utils::Path::path().getPackagesDir();
+    fs::path pkg = utils::Path::path().getBinaryPackagesDir();
     pkg /= package;
     pkg /= "plugins";
 
@@ -806,7 +806,7 @@ void ModuleManager::browse(const std::string& package, ModuleType type)
 {
     boost::mutex::scoped_lock lock(mPimpl->mMutex);
 
-    fs::path pkg = utils::Path::path().getPackagesDir();
+    fs::path pkg = utils::Path::path().getBinaryPackagesDir();
     pkg /= package;
     pkg /= "plugins";
 
@@ -989,29 +989,25 @@ std::string ModuleManager::buildModuleFilename(const std::string& package,
                                                ModuleType type)
 {
     fs::path current;
+    vle::utils::Package pkg(package);
 
     switch (type) {
         case MODULE_DYNAMICS:
         case MODULE_DYNAMICS_EXECUTIVE:
         case MODULE_DYNAMICS_WRAPPER:
-            current = Path::path().getExternalPackagePluginSimulatorDir(
-                package);
+            current = pkg.getPluginSimulatorDir(PKG_BINARY);
             break;
         case MODULE_OOV:
-            current = Path::path().getExternalPackagePluginOutputDir(
-                package);
+            current = pkg.getPluginOutputDir(PKG_BINARY);
             break;
         case MODULE_GVLE_GLOBAL:
-            current = Path::path().getExternalPackagePluginGvleGlobalDir(
-                package);
+            current = pkg.getPluginGvleGlobalDir(PKG_BINARY);
             break;
         case MODULE_GVLE_MODELING:
-            current = Path::path().getExternalPackagePluginGvleModelingDir(
-                package);
+            current = pkg.getPluginGvleModelingDir(PKG_BINARY);
             break;
         case MODULE_GVLE_OUTPUT:
-            current = Path::path().getExternalPackagePluginGvleOutputDir(
-                package);
+            current = pkg.getPluginGvleOutputDir(PKG_BINARY);
             break;
         default:
             throw utils::InternalError();

--- a/src/vle/utils/Package.cpp
+++ b/src/vle/utils/Package.cpp
@@ -26,7 +26,6 @@
 
 
 #include <vle/utils/Package.hpp>
-#include <vle/utils/Path.hpp>
 #include <vle/utils/Preferences.hpp>
 #include <vle/utils/Trace.hpp>
 #include <vle/utils/Exception.hpp>
@@ -51,8 +50,6 @@
 namespace fs = boost::filesystem;
 
 namespace vle { namespace utils {
-
-Package* Package::m_package = 0;
 
 /**
  * Build a vector of string from a command line.
@@ -79,11 +76,23 @@ static void buildCommandLine(const std::string& cmd,
 
 struct Package::Pimpl
 {
-    Pimpl() {}
+    Pimpl()
+    {
+    }
+
+    Pimpl(const std::string& pkgname) :
+        m_pkgname(pkgname), m_pkgbinarypath(""),
+        m_pkgsourcepath("")
+    {
+        refreshPath();
+    }
 
     ~Pimpl() {}
 
-    PackageTable m_table;
+    std::string  m_pkgname;
+    std::string  m_pkgbinarypath;
+    std::string  m_pkgsourcepath;
+
     Spawn        m_spawn;
     std::string  m_message;
     std::string  m_strout;
@@ -113,14 +122,43 @@ struct Package::Pimpl
 
         bool started = m_spawn.start(exe, workingDir, argv);
 
-        utils::Package::package().changeToOutputDirectory();
-
         if (not started) {
             throw utils::ArgError(fmt(_("Failed to start `%1%'")) % exe);
         }
     }
+
+    void refreshPath()
+    {
+        m_pkgbinarypath = "";
+        m_pkgsourcepath = "";
+        if (not m_pkgname.empty()) {
+            fs::path  path_binary = Path::path().getBinaryPackagesDir();
+            path_binary /= m_pkgname;
+            m_pkgbinarypath = path_binary.string();
+            fs::path path_source_dir = Path::path().getCurrentDir();
+            fs::path path_source_pkg = path_source_dir;
+            path_source_pkg /= m_pkgname;
+            if (fs::exists(path_source_pkg) ||
+                fs::exists(path_source_dir)) {
+                m_pkgsourcepath = path_source_pkg.string();
+            }
+        }
+    }
+
+    void select(const std::string& name)
+    {
+        m_pkgname = name;
+        m_pkgbinarypath = "";
+        m_pkgsourcepath = "";
+        refreshPath();
+    }
 };
 
+
+Package::Package(const std::string& pkgname)
+    : m_pimpl(new Package::Pimpl(pkgname))
+{
+}
 
 Package::Package()
     : m_pimpl(new Package::Pimpl())
@@ -134,82 +172,168 @@ Package::~Package()
 
 void Package::create()
 {
-    fs::create_directory(Path::path().getPackageSourceDir());
-    Path::path().copyTemplate("package", Path::path().getPackageSourceDir());
-
+    if (fs::exists(getDir(PKG_SOURCE))) {
+        throw utils::FileError( fmt(_("Pkg create error: "
+                "the directory %1% already exists")) % getDir(PKG_SOURCE));
+    }
+    refreshPath();
+    fs::create_directory(getDir(PKG_SOURCE));
+    Path::path().copyTemplate("package",getDir(PKG_SOURCE));
     m_pimpl->m_strout.append(_("Package creating - done\n"));
 }
 
 void Package::configure()
 {
-    fs::create_directory(Path::path().getPackageBuildDir());
+    std::string pkg_buildir = getBuildDir(PKG_SOURCE);
 
+    if (m_pimpl->mCommandConfigure.empty()) {
+        refreshCommands();
+    }
+    if (pkg_buildir.empty()) {
+        refreshPath();
+    }
+    if (m_pimpl->mCommandConfigure.empty() ||
+            pkg_buildir.empty()) {
+        throw utils::FileError(_("Pkg configure error: empty command"));
+    }
+    if (pkg_buildir.empty()) {
+        throw utils::FileError(
+                _("Pkg configure error: building directory path is empty"));
+    }
+    if (not fs::exists(pkg_buildir)) {
+        fs::create_directories(pkg_buildir);
+    }
+    fs::path old_dir = fs::current_path();
+    fs::current_path(pkg_buildir);
     std::vector < std::string > argv;
     std::string exe, cmd;
-
-    cmd = (vle::fmt(m_pimpl->mCommandConfigure) %
-           Path::path().getPackageBinaryDir()).str();
-
+    std::string pkg_binarydir = getDir(PKG_BINARY);
+    cmd = (vle::fmt(m_pimpl->mCommandConfigure) % pkg_binarydir).str();
     buildCommandLine(cmd, exe, argv);
-
     try {
-        m_pimpl->process(exe, Path::path().getPackageBuildDir(), argv);
+        m_pimpl->process(exe, pkg_buildir, argv);
     } catch(const std::exception& e) {
+        fs::current_path(old_dir);
         throw utils::InternalError(fmt(
-                _("Pkg configure error: configure failed %1%")) % e.what());
+                _("Pkg configure error: %1%")) % e.what());
     }
+    fs::current_path(old_dir);
 }
 
 void Package::test()
 {
-    fs::create_directory(Path::path().getPackageBuildDir());
+
+    std::string pkg_buildir = getBuildDir(PKG_SOURCE);
+    if (m_pimpl->mCommandBuild.empty()) {
+        refreshCommands();
+    }
+    if (pkg_buildir.empty()) {
+        refreshPath();
+    }
+    if (m_pimpl->mCommandBuild.empty() ||
+            pkg_buildir.empty()) {
+        throw utils::FileError(_("Pkg test error: empty command"));
+    }
+    if (pkg_buildir.empty()) {
+        throw utils::FileError(
+                _("Pkg test error: building directory path is empty"));
+    }
+    if (not fs::exists(pkg_buildir)) {
+        throw utils::FileError(
+                fmt(_("Pkg test error: building directory '%1%' "
+                        "does not exist ")) % pkg_buildir.c_str());
+    }
+    fs::path old_dir = fs::current_path();
+    fs::current_path(pkg_buildir);
 
     std::vector < std::string > argv;
     std::string exe, cmd;
 
-    cmd = (vle::fmt(m_pimpl->mCommandTest) %
-           Path::path().getPackageBuildDir()).str();
+    cmd = (vle::fmt(m_pimpl->mCommandTest) % pkg_buildir).str();
     buildCommandLine(cmd, exe, argv);
 
     try {
-        m_pimpl->process(exe, Path::path().getPackageBuildDir(), argv);
+        m_pimpl->process(exe, pkg_buildir, argv);
     } catch (const std::exception& e) {
+        fs::current_path(old_dir);
         throw utils::InternalError(
             fmt(_("Pkg error: test launch failed %1%")) % e.what());
     }
+    fs::current_path(old_dir);
 }
 
 void Package::build()
 {
-    fs::create_directory(Path::path().getPackageBuildDir());
+    std::string pkg_buildir = getBuildDir(PKG_SOURCE);
+    if (m_pimpl->mCommandBuild.empty()) {
+        refreshCommands();
+    }
+    if (pkg_buildir.empty()) {
+        refreshPath();
+    }
+    if (m_pimpl->mCommandBuild.empty() ||
+            pkg_buildir.empty()) {
+        throw utils::FileError(_("Pkg build error: empty command"));
+    }
+    if (pkg_buildir.empty()) {
+        throw utils::FileError(
+                _("Pkg build error: building directory path is empty"));
+    }
+    if (not fs::exists(pkg_buildir)) {
+        configure();
+    }
+    fs::path old_dir = fs::current_path();
+    fs::current_path(pkg_buildir);
 
     std::vector < std::string > argv;
     std::string exe, cmd;
 
-    cmd = (vle::fmt(m_pimpl->mCommandBuild) %
-           Path::path().getPackageBuildDir()).str();
+    cmd = (vle::fmt(m_pimpl->mCommandBuild) % pkg_buildir).str();
     buildCommandLine(cmd, exe, argv);
 
     try {
-        m_pimpl->process(exe, Path::path().getPackageBuildDir(), argv);
+        m_pimpl->process(exe, pkg_buildir, argv);
     } catch(const std::exception& e) {
+        fs::current_path(old_dir);
         throw utils::InternalError(fmt(
                 _("Pkg build error: build failed %1%")) % e.what());
     }
+    fs::current_path(old_dir);
 }
 
 void Package::install()
 {
-    fs::create_directory(Path::path().getPackageBuildDir());
+
+    std::string pkg_buildir = getBuildDir(PKG_SOURCE);
+    if (m_pimpl->mCommandBuild.empty()) {
+        refreshCommands();
+    }
+    if (pkg_buildir.empty()) {
+        refreshPath();
+    }
+    if (m_pimpl->mCommandBuild.empty() ||
+            pkg_buildir.empty()) {
+        throw utils::FileError(_("Pkg install error: empty command"));
+    }
+    if (pkg_buildir.empty()) {
+        throw utils::FileError(
+                _("Pkg install error: building directory path is empty"));
+    }
+    if (not fs::exists(pkg_buildir)) {
+        throw utils::FileError(
+                fmt(_("Pkg install error: building directory '%1%' "
+                        "does not exist ")) % pkg_buildir.c_str());
+    }
+    fs::path old_dir = fs::current_path();
+    fs::current_path(pkg_buildir);
 
     std::vector < std::string > argv;
     std::string exe, cmd;
 
-    cmd = (vle::fmt(m_pimpl->mCommandInstall) %
-           Path::path().getPackageBuildDir()).str();
+    cmd = (vle::fmt(m_pimpl->mCommandInstall) % pkg_buildir).str();
     buildCommandLine(cmd, exe, argv);
 
-    fs::path builddir = Path::path().getPackageBuildDir();
+    fs::path builddir = pkg_buildir;
 
     if (not fs::exists(builddir)) {
         throw utils::ArgError(
@@ -232,45 +356,63 @@ void Package::install()
     }
 
     try {
-        m_pimpl->process(exe, Path::path().getPackageBuildDir(), argv);
+        m_pimpl->process(exe, pkg_buildir, argv);
     } catch(const std::exception& e) {
+        fs::current_path(old_dir);
         throw utils::InternalError(
             fmt(_("Pkg build error: install lib failed %1%")) % e.what());
     }
+    fs::current_path(old_dir);
 }
 
 void Package::clean()
 {
-    fs::create_directory(Path::path().getPackageBuildDir());
-
-    std::vector < std::string > argv;
-    std::string exe, cmd;
-
-    cmd = (vle::fmt(m_pimpl->mCommandClean) %
-           Path::path().getPackageBuildDir()).str();
-    buildCommandLine(cmd, exe, argv);
-
-    try {
-        m_pimpl->process(exe, Path::path().getPackageBuildDir(), argv);
-    } catch(const std::exception& e) {
-        throw utils::InternalError(fmt(
-                _("Pkg clean error: clean failed %1%")) % e.what());
+    fs::path pkg_buildir = getBuildDir(PKG_SOURCE);
+    if (fs::exists(pkg_buildir)) {
+        fs::remove_all(pkg_buildir);
+        fs::remove(pkg_buildir);
     }
 }
 
+
+void Package::rclean()
+{
+    fs::path pkg_buildir = getDir(PKG_BINARY);
+    if (fs::exists(pkg_buildir)) {
+        fs::remove_all(pkg_buildir);
+        fs::remove(pkg_buildir);
+    }
+}
+
+
 void Package::pack()
 {
-    fs::create_directory(Path::path().getPackageBuildDir());
+    std::string pkg_buildir = getBuildDir(PKG_SOURCE);
+    if (m_pimpl->mCommandBuild.empty()) {
+        refreshCommands();
+    }
+    if (pkg_buildir.empty()) {
+        refreshPath();
+        pkg_buildir = getBuildDir(PKG_SOURCE);
+    }
+    if (m_pimpl->mCommandBuild.empty()) {
+        throw utils::FileError(_("Pkg packaging error: empty command"));
+    }
+    if (pkg_buildir.empty()) {
+        throw utils::FileError(_("Pkg packaging error: "
+                "no building directory found"));
+    }
+
+    fs::create_directory(pkg_buildir);
 
     std::vector < std::string > argv;
     std::string exe, cmd;
 
-    cmd = (vle::fmt(m_pimpl->mCommandPack) %
-           Path::path().getPackageBuildDir()).str();
+    cmd = (vle::fmt(m_pimpl->mCommandPack) % pkg_buildir).str();
     buildCommandLine(cmd, exe, argv);
 
     try {
-        m_pimpl->process(exe, Path::path().getPackageBuildDir(), argv);
+        m_pimpl->process(exe, pkg_buildir, argv);
     } catch(const std::exception& e) {
         throw utils::InternalError(fmt(
                 _("Pkg packaging error: package failed %1%")) % e.what());
@@ -335,125 +477,347 @@ bool Package::get(std::string *out, std::string *err)
     return false;
 }
 
-void Package::changeToOutputDirectory()
+void Package::select(const std::string& name)
 {
-    if (utils::Package::package().selected()) {
-        namespace fs = boost::filesystem;
+    m_pimpl->select(name);
+}
 
-        fs::path outputdir = utils::Path::path().getPackageOutputDir();
+void Package::remove(const std::string& toremove, VLE_PACKAGE_TYPE type)
+{
+    std::string pkg_dir = getDir(type);
+    fs::path torm(pkg_dir);
+    torm /= toremove;
 
-        if (not fs::exists(outputdir)) {
-            fs::create_directories(outputdir);
-            g_chdir(outputdir.string().c_str());
-        } else {
-            if (fs::is_directory(outputdir)) {
-                g_chdir(outputdir.string().c_str());
-            }
-        }
+    if (fs::exists(torm)) {
+        fs::remove_all(torm);
+        fs::remove(torm);
+    }
+
+}
+
+std::string Package::getParentDir(VLE_PACKAGE_TYPE type) const
+{
+    std::string base_dir = getDir(type);
+    if (base_dir.empty()){
+        return "";
+    } else {
+        fs::path base_path = fs::path(base_dir);
+        return base_path.branch_path().string();
     }
 }
 
-void Package::removePackage(const std::string& package)
+std::string Package::getDir(VLE_PACKAGE_TYPE type) const
 {
-    Package::removePackageBinary(package);
+    switch (type) {
+    case PKG_SOURCE:
+        return m_pimpl->m_pkgsourcepath;
+        break;
+    case PKG_BINARY:
+        return m_pimpl->m_pkgbinarypath;
+        break;
+    }
+    return "";
 }
 
-void Package::removePackageBinary(const std::string& package)
+std::string Package::getLibDir(VLE_PACKAGE_TYPE type) const
 {
-    (void)package;
-
-    if (Path::path().getPackageBinaryDir().empty())
-        return;
-
-    if (fs::exists(Path::path().getPackageBinaryDir())) {
-        fs::remove_all(Path::path().getPackageBinaryDir());
-        fs::remove(Path::path().getPackageBinaryDir());
-    }
+    return utils::Path::buildDirname(getDir(type), "lib");
 }
 
-bool Package::existsPackage(const std::string& package)
+std::string Package::getSrcDir(VLE_PACKAGE_TYPE type) const
 {
-    if (not package.empty()) {
-        fs::path tmp = Path::path().getPackagesDir();
-        tmp /= package;
+    return utils::Path::buildDirname(getDir(type), "src");
+}
 
-        return fs::exists(tmp);
+std::string Package::getDataDir(VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "data");
+}
+
+std::string Package::getDocDir(VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "doc");
+}
+
+std::string Package::getExpDir(VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "exp");
+}
+
+std::string Package::getBuildDir(VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "buildvle");
+}
+
+std::string Package::getOutputDir(VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "output");
+}
+
+std::string Package::getPluginDir(VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "plugins");
+}
+
+std::string Package::getPluginSimulatorDir(VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "plugins", "simulator");
+}
+
+std::string Package::getPluginOutputDir(VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "plugins", "output");
+}
+
+std::string Package::getPluginGvleGlobalDir(VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "plugins", "gvle", "global");
+}
+
+std::string Package::getPluginGvleModelingDir(VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "plugins", "gvle",
+            "modeling");
+}
+
+std::string Package::getPluginGvleOutputDir(VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "plugins", "gvle", "output");
+}
+
+std::string Package::getFile(const std::string& file,
+        VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), file);
+}
+
+std::string Package::getLibFile(const std::string& file,
+        VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "lib", file);
+}
+
+std::string Package::getSrcFile(const std::string& file,
+        VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "src", file);
+}
+
+std::string Package::getDataFile(const std::string& file,
+        VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "data", file);
+}
+
+std::string Package::getDocFile(const std::string& file,
+        VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "doc", file);
+}
+
+std::string Package::getExpFile(const std::string& file,
+        VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "exp", file);
+}
+
+std::string Package::getOutputFile(const std::string& file,
+        VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "output", file);
+}
+
+std::string Package::getPluginFile(const std::string& file,
+        VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "plugins", file);
+}
+
+std::string Package::getPluginSimulatorFile(const std::string& file,
+        VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "plugins", "simulator",
+            file);
+}
+
+std::string Package::getPluginOutputFile(const std::string& file,
+        VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(getDir(type), "plugins", "output", file);
+}
+
+std::string Package::getPluginGvleModelingFile(const std::string& file,
+        VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(
+        getDir(type), "plugins", "gvle", "modeling", file);
+}
+
+std::string Package::getPluginGvleOutputFile(const std::string& file,
+        VLE_PACKAGE_TYPE type) const
+{
+    return utils::Path::buildDirname(
+        getDir(type), "plugins", "gvle", "output", file);
+}
+
+bool Package::existsBinary() const
+{
+    fs::path binary_dir = m_pimpl->m_pkgbinarypath;
+    return (fs::exists(binary_dir) && fs::is_directory(binary_dir));
+}
+
+bool Package::existsSource() const
+{
+    return (not m_pimpl->m_pkgsourcepath.empty());
+}
+
+bool Package::existsFile(const std::string& path, VLE_PACKAGE_TYPE type)
+{
+    std::string base_dir = getDir(type);
+    if (not base_dir.empty()) {
+        fs::path tmp(base_dir);
+        tmp /= path;
+        return fs::exists(tmp) && fs::is_regular_file(tmp);
     }
-
     return false;
 }
 
-void Package::addFile(const std::string& path, const std::string& name)
+void Package::addDirectory(const std::string& path, const std::string& name,
+        VLE_PACKAGE_TYPE type)
 {
-    if (Package::package().selected()) {
-        fs::path tmp = Path::path().getPackageSourceDir();
+    std::string base_dir = getDir(type);
+    if (not base_dir.empty()) {
+        fs::path tmp(base_dir);
         tmp /= path;
         tmp /= name;
-
-        if (not fs::exists(tmp)) {
-#if BOOST_VERSION > 104500
-            std::ofstream file(tmp.string().c_str());
-#else
-            std::ofstream file(tmp.file_string().c_str());
-#endif
-        }
-    }
-}
-
-bool Package::existsFile(const std::string& path)
-{
-    if (Package::package().selected()) {
-        fs::path tmp = Path::path().getPackageSourceDir();
-        tmp /= path;
-
-#if BOOST_VERSION > 103600
-        return fs::exists(tmp) and fs::is_regular_file(tmp);
-#else
-        return fs::exists(tmp) and fs::is_regular(tmp);
-#endif
-    }
-
-    return false;
-}
-
-void Package::addDirectory(const std::string& path, const std::string& name)
-{
-    if (Package::package().selected()) {
-        fs::path tmp(Path::path().getPackageSourceDir());
-        tmp /= path;
-        tmp /= name;
-
         if (not fs::exists(tmp)) {
             fs::create_directory(tmp);
         }
     }
 }
 
-bool Package::existsDirectory(const std::string& path)
+PathList Package::getExperiments(VLE_PACKAGE_TYPE type) const
 {
-    if (Package::package().selected()) {
-        fs::path tmp = Path::path().getPackageSourceDir();
-        tmp /= path;
-
-        return fs::exists(tmp) and fs::is_directory(tmp);
+    fs::path pkg(getExpDir(type));
+    if (not fs::exists(pkg) or not fs::is_directory(pkg)) {
+        throw utils::InternalError(fmt(
+                _("Pkg list error: '%1%' is not an experiments directory")) %
+#if BOOST_VERSION > 104500
+            pkg.string());
+#else
+            pkg.file_string());
+#endif
     }
 
-    return false;
+    PathList result;
+    std::stack < fs::path > stack;
+    stack.push(pkg);
+
+    while (not stack.empty()) {
+        fs::path dir = stack.top();
+        stack.pop();
+
+        for (fs::directory_iterator it(dir), end; it != end; ++it) {
+#if BOOST_VERSION > 104500
+            if (fs::is_regular_file(it->status())) {
+                std::string ext = it->path().extension().string();
+#elif BOOST_VERSION > 103600
+            if (fs::is_regular_file(it->status())) {
+                fs::path::string_type ext = it->path().extension();
+#else
+            if (fs::is_regular(it->status())) {
+                fs::path::string_type ext = fs::extension(it->path());
+#endif
+                if (ext == ".vpz") {
+#if BOOST_VERSION > 104500
+                    result.push_back(it->path().string());
+#else
+                    result.push_back(it->path().file_string());
+#endif
+                }
+            } else if (fs::is_directory(it->status())) {
+                stack.push(it->path());
+            }
+        }
+    }
+    return result;
 }
 
-void Package::remove(const std::string& path)
+PathList Package::listLibraries(const std::string& path) const
 {
-    fs::path tmp = Path::path().getPackageSourceDir();
-    tmp /= path;
+    PathList result;
+    fs::path simdir(path);
+    if (fs::exists(simdir) and fs::is_directory(simdir)) {
+        std::stack < fs::path > stack;
+        stack.push(simdir);
+        while (not stack.empty()) {
+            fs::path dir = stack.top();
+            stack.pop();
+            for (fs::directory_iterator it(dir), end; it != end; ++it) {
+#if BOOST_VERSION > 104500
+                if (fs::is_regular_file(it->status())) {
+                    std::string ext = it->path().extension().string();
+#elif BOOST_VERSION > 103600
+                if (fs::is_regular_file(it->status())) {
+                    fs::path::string_type ext = it->path().extension();
+#else
+                if (fs::is_regular(it->status())) {
+                    fs::path::string_type ext = fs::extension(it->path());
+#endif
 
-    fs::remove_all(tmp);
-    fs::remove(tmp);
+#ifdef G_OS_WINDOWS
+                    if (ext == ".dll") {
+#elif G_OS_MACOS
+                    if (ext == ".dylib") {
+#else
+                    if (ext == ".so") {
+#endif
+
+#if BOOST_VERSION > 104500
+                        result.push_back(it->path().string());
+#else
+                        result.push_back(it->path().file_string());
+#endif
+                    } else if (fs::is_directory(it->status())) {
+                        stack.push(it->path());
+                    }
+                }
+            }
+       }
+   }
+   return result;
+}
+
+PathList Package::getPluginsSimulator() const
+{
+    return listLibraries(getPluginSimulatorDir(PKG_BINARY));
+}
+
+PathList Package::getPluginsOutput() const
+{
+    return listLibraries(getPluginOutputDir(PKG_BINARY));
+}
+
+PathList Package::getPluginsGvleGlobal() const
+{
+    return listLibraries(getPluginGvleGlobalDir(PKG_BINARY));
+}
+
+PathList Package::getPluginsGvleModeling() const
+{
+    return listLibraries(getPluginGvleModelingDir(PKG_BINARY));
+}
+
+PathList Package::getPluginsGvleOutput() const
+{
+    return listLibraries(getPluginGvleOutputDir(PKG_BINARY));
 }
 
 std::string Package::rename(const std::string& oldname,
-                            const std::string& newname)
+        const std::string& newname,
+        VLE_PACKAGE_TYPE type)
 {
-    fs::path oldfilepath = Path::path().getPackageSourceDir();
+    fs::path oldfilepath = getDir(type);
     oldfilepath /= oldname;
 
 #if BOOST_VERSION > 103600
@@ -489,26 +853,10 @@ void Package::copy(const std::string& source, std::string& target)
 
 const std::string& Package::name() const
 {
-    return m_pimpl->m_table.current();
+    return m_pimpl->m_pkgname;
 }
 
-bool Package::selected() const
-{
-    return not m_pimpl->m_table.current().empty();
-}
-
-void Package::select(const std::string& name)
-{
-    m_pimpl->m_table.current(name);
-
-    Path::path().updateDirs();
-
-    if (selected()) {
-        changeToOutputDirectory();
-    }
-}
-
-void Package::refresh()
+void Package::refreshCommands()
 {
     utils::Preferences prefs;
 
@@ -521,9 +869,33 @@ void Package::refresh()
     prefs.get("vle.packages.unzip", &m_pimpl->mCommandUnzip);
 }
 
-PackageTable::index Package::getId(const std::string& package)
+void Package::refreshPath()
 {
-    return m_pimpl->m_table.get(package);
+    m_pimpl->refreshPath();
+}
+
+VLE_API std::ostream& operator<<(std::ostream& out,
+        const VLE_PACKAGE_TYPE& type)
+{
+    switch (type) {
+    case PKG_SOURCE:
+        out << "SOURCE";
+        break;
+    case PKG_BINARY:
+        out << "BINARY";
+        break;
+    }
+    return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const Package& pkg)
+{
+    out << "\npackage name.....: " << pkg.m_pimpl->m_pkgname << "\n"
+        << "source path........: " << pkg.m_pimpl->m_pkgsourcepath << "\n"
+        << "binary path........: " << pkg.m_pimpl->m_pkgbinarypath << "\n"
+        << "exists binary......: " << pkg.existsBinary() << "\n"
+        << "\n";
+    return out;
 }
 
 }} // namespace vle utils

--- a/src/vle/utils/Package.hpp
+++ b/src/vle/utils/Package.hpp
@@ -30,6 +30,7 @@
 
 #include <vle/DllDefines.hpp>
 #include <vle/utils/PackageTable.hpp>
+#include <vle/utils/Path.hpp>
 #include <string>
 
 namespace vle { namespace utils {
@@ -47,10 +48,31 @@ namespace vle { namespace utils {
  * utils::Package::Package().configure(std::cout, std::cerr);
  * @endcode
  */
+
+enum VLE_PACKAGE_TYPE {
+    PKG_BINARY,
+    PKG_SOURCE
+};
+
+VLE_API std::ostream& operator<<(std::ostream& out,
+        const VLE_PACKAGE_TYPE& type);
+
 class VLE_API Package
 {
 public:
+
+    Package();
+
+    Package(const std::string& pkgname);
+
     ~Package();
+
+    const std::string& name() const;
+
+    /**
+     * Selects the package
+     */
+    void select(const std::string& name);
 
     /**
      * Build the package.
@@ -81,13 +103,18 @@ public:
     void install();
 
     /**
-     * Clean the package by running the 'make clean' command and
-     * remove the CMakeCache.txt file.
+     * Clean the package by running removing the "buildvle"
+     * directory of the source package
      */
     void clean();
 
     /**
-     * Pack the package by runngin the 'make package' and 'make
+     * Remove the binary package
+     */
+    void rclean();
+
+    /**
+     * Pack the package by running the 'make package' and 'make
      * package_source' command.
      */
     void pack();
@@ -125,31 +152,6 @@ public:
      */
     bool get(std::string *out, std::string *err);
 
-    /**
-     * Change the current directory to the output directory. If we
-     * are in package mode, the output directory will be create. If a file
-     * named output directory exists, nothing is done.
-     */
-    void changeToOutputDirectory();
-
-    /**
-     * Remove the specified package from the user directory.
-     *
-     * @param package The package to remove (recursively).
-     */
-    void removePackage(const std::string& package);
-
-    /**
-     * Remove the binary directory of the package:
-     * - $VLE_HOME/pkgs/package/build
-     * - $VLE_HOME/pkgs/package/lib
-     * - $VLE_HOME/pkgs/package/plugins
-     * - $VLE_HOME/pkgs/package/doc/html
-     *
-     * @param package The \c package to remove binary directories.
-     */
-    static void removePackageBinary(const std::string& package);
-
 
     /**
      * Test if the specified package exists in the user directory.
@@ -158,27 +160,84 @@ public:
      *
      * @return true if the package already exist, false otherwise.
      */
-    bool existsPackage(const std::string& package);
+    bool existsSource() const;
 
     /**
-     * Add an empty file into the current Package.
+     * Test if the specified package exists as a binary package.
      *
-     * @param path The path, for example: "data" to build a new file
-     * "PKG/data/name".
-     * @param name The name of the file.
+     * @param package The package to test.
+     *
+     * @return true if the package already exist, false otherwise.
      */
-    void addFile(const std::string& path, const std::string& name);
+    bool existsBinary() const;
+
+    std::string getParentDir(VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getDir(VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getLibDir(VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getSrcDir(VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getDataDir(VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getDocDir(VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getExpDir(VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getBuildDir(VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getOutputDir(VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getPluginDir(VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getPluginSimulatorDir(VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getPluginOutputDir(VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getPluginGvleGlobalDir(
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getPluginGvleModelingDir(
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getPluginGvleOutputDir(
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+
+    std::string getFile(const std::string& file,
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getLibFile(const std::string& file,
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getSrcFile(const std::string& file,
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getDataFile(const std::string& file,
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getDocFile(const std::string& file,
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getExpFile(const std::string& file,
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getOutputFile(const std::string& file,
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getPluginFile(const std::string& file,
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getPluginSimulatorFile(const std::string& file,
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getPluginOutputFile(const std::string& file,
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getPluginGvleModelingFile(const std::string& file,
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+    std::string getPluginGvleOutputFile(const std::string& file,
+            VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+
+    PathList getExperiments(VLE_PACKAGE_TYPE type = PKG_BINARY) const;
+
+    PathList getPluginsSimulator() const;
+    PathList getPluginsOutput() const;
+    PathList getPluginsGvleGlobal() const;
+    PathList getPluginsGvleModeling() const;
+    PathList getPluginsGvleOutput() const;
+
 
     /**
      * Return true if a file package/path/to/file exists in the
      * package package.
      *
+     *
      * @param path The path, for example: "data/input1.dat" to test a file
      * "PKG/data/input1.dat".
+     * @param type The type of package
      *
      * @return true if file exists, false otherwise.
      */
-    bool existsFile(const std::string& path);
+    bool existsFile(const std::string& path,
+            VLE_PACKAGE_TYPE type = PKG_BINARY);
+
 
     /**
      * Add an empty directgory into the current Package.
@@ -186,26 +245,32 @@ public:
      * @param path The path, for example: "data" to build a new directory
      * "PKG/data/name".
      * @param name The name of the directory.
+     * @param type The type of package
      */
-    void addDirectory(const std::string& path, const std::string& name);
+    void addDirectory(const std::string& path, const std::string& name,
+            VLE_PACKAGE_TYPE type = PKG_BINARY);
 
     /**
      * Return true if a directory package/path/to/file exists in the
      * package package.
      *
+     * @param type The type of package
      * @param path The path, for example: "data/input1.dat" to test a file
      * "PKG/data/input1.dat".
      *
      * @return true if directory exists, false otherwise.
      */
-    bool existsDirectory(const std::string& path);
+    bool existsDirectory(const std::string& path,
+            VLE_PACKAGE_TYPE type = PKG_BINARY);
 
     /**
      * Remove file or directory and (recursively) the specified path.
      *
-     * @param path The name of the file or the directory.
+     * @param toremove The name of the file or the directory.
+     * @param type The type of package
      */
-    void remove(const std::string& path);
+    void remove(const std::string& toremove,
+            VLE_PACKAGE_TYPE type = PKG_BINARY);
 
     /**
      * Rename the path oldname to the new name newname.
@@ -217,14 +282,15 @@ public:
      *
      * @param oldname The path, in PKG, of the file to rename.
      * @param newname The new name.
+     * @param type The type of package
      *
      * @return The string representation of the path of the new file.
      *
      * @throw utils::ArgError if the file already exists or if the old file
      * does not exist.
      */
-    std::string rename(const std::string& oldname,
-                       const std::string& newname);
+    std::string rename(const std::string& oldname, const std::string& newname,
+            VLE_PACKAGE_TYPE type = PKG_BINARY);
 
     /**
      * Copy the file.
@@ -235,69 +301,30 @@ public:
     void copy(const std::string& source, std::string& target);
 
     /**
-     * Get the name of the current selected Package. Get the current
-     * selected Package. If the name is empty, no package is selected.
-     * @return The current selected Package.
+     * Refresh the command line option from the `vle.conf' file.
      */
-    const std::string& name() const;
-
-    /**
-     * Is a package selected.
-     * @return Return true if a Package is selected, false otherwise.
-     */
-    bool selected() const;
-
-    /**
-     * Select a new Package.
-     * @param name The new Package.
-     */
-    void select(const std::string& name);
+    void refreshCommands();
 
     /**
      * Refresh the command line option from the `vle.conf' file.
      */
-    void refresh();
+    void refreshPath();
 
-    /**
-     * Get an identifiant for the specified package. If the name is
-     * not defined in the table list, it will be add.
-     *
-     * @param name The package to get an Id.
-     * @return An id.
-     */
-    PackageTable::index getId(const std::string& package);
-
-    /*   manage singleton   */
-
-    /**
-     * Return a instance of Package using the singleton system.
-     * @return A reference to the singleton object.
-     */
-    inline static Package& package()
-    { if (m_package == 0) m_package = new Package; return *m_package; }
-
-    /**
-     * Initialise the Package singleton.
-     */
-    inline static void init()
-    { package(); }
-
-    /**
-     * Delete the Package singleton.
-     */
-    inline static void kill()
-    { delete m_package; m_package = 0; }
+    friend std::ostream& operator<<(std::ostream& out, const Package& pkg);
 
 private:
-    Package();
     Package(const Package&);
     Package& operator=(const Package&);
 
-    static Package* m_package; ///< singleton attribute.
+
+    PathList listLibraries(const std::string& path) const;
 
     struct Pimpl;
     Pimpl *m_pimpl;
+
 };
+
+VLE_API std::ostream& operator<<(std::ostream& out, const Package& pkg);
 
 }} // namespace vle utils
 

--- a/src/vle/utils/PackageTable.cpp
+++ b/src/vle/utils/PackageTable.cpp
@@ -35,12 +35,6 @@ PackageTable::PackageTable()
     m_current = m_table.insert(std::string()).first;
 }
 
-void PackageTable::current(const std::string& package)
-{
-    std::pair < const_iterator, bool > r = m_table.insert(package);
-    m_current = r.first;
-}
-
 PackageTable::index PackageTable::get(const std::string& package)
 {
     return m_table.insert(package).first;

--- a/src/vle/utils/PackageTable.hpp
+++ b/src/vle/utils/PackageTable.hpp
@@ -46,19 +46,6 @@ namespace vle { namespace utils {
         PackageTable();
 
         /**
-         * @brief Assign a new current package.
-         * @param package The new package. Can be null if no package is
-         * defined.
-         */
-        void current(const std::string& package);
-
-        /**
-         * @brief Get the current selected package.
-         * @return A constant reference to the selected package.
-         */
-        const std::string& current() const { return *m_current; }
-
-        /**
          * @brief Get an index to the specified package, if package does not
          * exist it is added.
          * @param package The package to get or add.

--- a/src/vle/utils/Path.cpp
+++ b/src/vle/utils/Path.cpp
@@ -34,7 +34,7 @@
 #endif
 
 #include <vle/utils/Path.hpp>
-#include <vle/utils/Package.hpp>
+//#include <vle/utils/Package.hpp>
 #include <vle/utils/Exception.hpp>
 #include <vle/utils/i18n.hpp>
 #include <vle/version.hpp>
@@ -92,7 +92,7 @@ std::string Path::getGladeFile(const std::string& file) const
  * packages path
  */
 
-std::string Path::getPackagesDir() const
+std::string Path::getBinaryPackagesDir() const
 {
     return buildDirname(m_home, pkgdirname);
 }
@@ -181,299 +181,19 @@ void Path::copyTemplate(const std::string& name, const std::string& to) const
     }
 }
 
-std::string Path::getPackageSourceDir() const
+std::string Path::getCurrentDir() const
 {
-    return m_currentPackageSourcePath;
+    return fs::current_path().string();
 }
 
-std::string Path::getPackageBinaryDir() const
+PathList Path::getBinaryPackages()
 {
-    return m_currentPackagePath;
-}
-
-std::string Path::getPackageLibDir() const
-{
-    return buildDirname(m_currentPackagePath, "lib");
-}
-
-std::string Path::getPackageSrcDir() const
-{
-    return buildDirname(m_currentPackagePath, "src");
-}
-
-std::string Path::getPackageDataDir() const
-{
-    return buildDirname(m_currentPackagePath, "data");
-}
-
-std::string Path::getPackageExpDir() const
-{
-    return buildDirname(m_currentPackagePath, "exp");
-}
-
-std::string Path::getPackageOutputDir() const
-{
-    return buildDirname(m_currentPackagePath, "output");
-}
-
-std::string Path::getPackagePluginDir() const
-{
-    return buildDirname(m_currentPackagePath, "plugins");
-}
-
-std::string Path::getPackagePluginSimulatorDir() const
-{
-    return buildDirname(m_currentPackagePath, "plugins", "simulator");
-}
-
-std::string Path::getPackagePluginOutputDir() const
-{
-    return buildDirname(m_currentPackagePath, "plugins", "output");
-}
-
-std::string Path::getPackagePluginGvleGlobalDir() const
-{
-    return buildDirname(m_currentPackagePath, "plugins", "gvle", "global");
-}
-
-std::string Path::getPackagePluginGvleModelingDir() const
-{
-    return buildDirname(m_currentPackagePath, "plugins", "gvle", "modeling");
-}
-
-std::string Path::getPackagePluginGvleOutputDir() const
-{
-    return buildDirname(m_currentPackagePath, "plugins", "gvle", "output");
-}
-
-std::string Path::getPackageBuildDir() const
-{
-    return buildDirname(m_currentPackageSourcePath, "buildvle");
-}
-
-std::string Path::getPackageDocDir() const
-{
-    return buildDirname(m_currentPackagePath, "doc");
-}
-
-std::string Path::getPackageFile(const std::string& name) const
-{
-    return buildFilename(getPackageSourceDir(), name);
-}
-
-std::string Path::getPackageLibFile(const std::string& name) const
-{
-    return buildFilename(getPackageLibDir(), name);
-}
-
-std::string Path::getPackageSrcFile(const std::string& name) const
-{
-    return buildFilename(getPackageSrcDir(), name);
-}
-
-std::string Path::getPackageDataFile(const std::string& name) const
-{
-    return buildFilename(getPackageDataDir(), name);
-}
-
-std::string Path::getPackageExpFile(const std::string& name) const
-{
-    return buildFilename(getPackageExpDir(), name);
-}
-
-std::string Path::getPackageOutputFile(const std::string& name) const
-{
-    return buildFilename(getPackageOutputDir(), name);
-}
-
-std::string Path::getPackageDocFile(const std::string& name) const
-{
-    return buildFilename(getPackageDocDir(), name);
-}
-
-std::string Path::getPackagePluginFile(const std::string& name) const
-{
-    return buildDirname(m_currentPackagePath, "plugins", name);
-}
-
-std::string Path::getPackagePluginSimulatorFile(const std::string& name) const
-{
-    return buildDirname(m_currentPackagePath, "plugins", "simulator", name);
-}
-
-std::string Path::getPackagePluginOutputFile(const std::string& name) const
-{
-    return buildDirname(m_currentPackagePath, "plugins", "output", name);
-}
-
-std::string Path::getPackagePluginGvleOutputFile(const std::string& name) const
-{
-    return buildDirname(m_currentPackagePath, "plugins", "gvle", "output", name);
-}
-
-std::string Path::getExternalPackageDir(const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name);
-}
-
-std::string Path::getExternalPackageLibDir(const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name, "lib");
-}
-
-std::string Path::getExternalPackageSrcDir(const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name, "src");
-}
-
-std::string Path::getExternalPackageDataDir(const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name, "data");
-}
-
-std::string Path::getExternalPackageDocDir(const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name, "doc");
-}
-
-std::string Path::getExternalPackageExpDir(const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name, "exp");
-}
-
-std::string Path::getExternalPackageBuildDir(const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name, "build");
-}
-
-std::string Path::getExternalPackageOutputDir(const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name, "plugins");
-}
-
-std::string Path::getExternalPackagePluginDir(const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name, "plugins");
-}
-
-std::string Path::getExternalPackagePluginSimulatorDir(
-    const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name, "plugins", "simulator");
-}
-
-std::string Path::getExternalPackagePluginOutputDir(
-    const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name, "plugins", "output");
-}
-
-std::string Path::getExternalPackagePluginGvleGlobalDir(
-    const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name, "plugins", "gvle", "global");
-}
-
-std::string Path::getExternalPackagePluginGvleModelingDir(
-    const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name, "plugins", "gvle", "modeling");
-}
-
-std::string Path::getExternalPackagePluginGvleOutputDir(
-    const std::string& name) const
-{
-    return buildDirname(getPackagesDir(), name, "plugins", "gvle", "output");
-}
-
-std::string Path::getExternalPackageFile(const std::string& name,
-                                         const std::string& file) const
-{
-    return buildFilename(getPackagesDir(), name, file);
-}
-
-std::string Path::getExternalPackageLibFile(const std::string& name,
-                                            const std::string& file) const
-{
-    return buildFilename(getPackagesDir(), name, "lib", file);
-}
-
-std::string Path::getExternalPackageSrcFile(const std::string& name,
-                                            const std::string& file) const
-{
-    return buildFilename(getPackagesDir(), name, "src", file);
-}
-
-std::string Path::getExternalPackageDataFile(const std::string& name,
-                                             const std::string& file) const
-{
-    return buildFilename(getPackagesDir(), name, "data", file);
-}
-
-std::string Path::getExternalPackageDocFile(const std::string& name,
-                                            const std::string& file) const
-{
-    return buildFilename(getPackagesDir(), name, "doc", file);
-}
-
-std::string Path::getExternalPackageExpFile(const std::string& name,
-                                            const std::string& file) const
-{
-    return buildFilename(getPackagesDir(), name, "exp", file);
-}
-
-std::string Path::getExternalPackageOutputFile(
-    const std::string& package,
-    const std::string& file) const
-{
-    return buildFilename(getPackagesDir(), package, "output", file);
-}
-
-std::string Path::getExternalPackagePluginFile(
-    const std::string& package,
-    const std::string& file) const
-{
-    return buildFilename(getPackagesDir(), package, "plugins", file);
-}
-
-std::string Path::getExternalPackagePluginSimulatorFile(
-    const std::string& package,
-    const std::string& file) const
-{
-    return buildFilename(getPackagesDir(), package, "plugins", "simulator", file);
-}
-
-std::string Path::getExternalPackagePluginOutputFile(
-    const std::string& package,
-    const std::string& file) const
-{
-    return buildFilename(getPackagesDir(), package, "plugins", "output", file);
-}
-
-std::string Path::getExternalPackagePluginGvleModelingFile(
-    const std::string& package,
-    const std::string& file) const
-{
-    return buildFilename(
-        getPackagesDir(), package, "plugins", "gvle", "modeling", file);
-}
-
-std::string Path::getExternalPackagePluginGvleOutputFile(
-    const std::string& package,
-    const std::string& file) const
-{
-    return buildFilename(
-        getPackagesDir(), package, "plugins", "gvle", "output", file);
-}
-
-PathList Path::getInstalledPackages()
-{
-    fs::path pkgs(Path::path().getPackagesDir());
+    fs::path pkgs(Path::path().getBinaryPackagesDir());
 
     if (not fs::exists(pkgs) or not fs::is_directory(pkgs)) {
         throw utils::InternalError(fmt(
                 _("Package error: '%1%' is not a directory")) %
-            Path::path().getPackagesDir());
+            Path::path().getBinaryPackagesDir());
     }
 
     PathList result;
@@ -492,55 +212,9 @@ PathList Path::getInstalledPackages()
     return result;
 }
 
-PathList Path::getInstalledExperiments()
-{
-    fs::path pkgs(Path::path().getPackageExpDir());
 
-    if (not fs::exists(pkgs) or not fs::is_directory(pkgs)) {
-        throw utils::InternalError(fmt(
-                _("Pkg list error: '%1%' is not an experiments directory")) %
-#if BOOST_VERSION > 104500
-            pkgs.string());
-#else
-            pkgs.file_string());
-#endif
-    }
 
-    PathList result;
-    std::stack < fs::path > stack;
-    stack.push(pkgs);
-
-    while (not stack.empty()) {
-        fs::path dir = stack.top();
-        stack.pop();
-
-        for (fs::directory_iterator it(dir), end; it != end; ++it) {
-#if BOOST_VERSION > 104500
-            if (fs::is_regular_file(it->status())) {
-                std::string ext = it->path().extension().string();
-#elif BOOST_VERSION > 103600
-            if (fs::is_regular_file(it->status())) {
-                fs::path::string_type ext = it->path().extension();
-#else
-            if (fs::is_regular(it->status())) {
-                fs::path::string_type ext = fs::extension(it->path());
-#endif
-                if (ext == ".vpz") {
-#if BOOST_VERSION > 104500
-                    result.push_back(it->path().string());
-#else
-                    result.push_back(it->path().file_string());
-#endif
-                }
-            } else if (fs::is_directory(it->status())) {
-                stack.push(it->path());
-            }
-        }
-    }
-    return result;
-}
-
-PathList Path::getInstalledLibraries()
+PathList Path::getBinaryLibraries()
 {
     PathList result;
     const PathList& dirs = Path::path().getSimulatorDirs();
@@ -595,7 +269,7 @@ PathList Path::getInstalledLibraries()
 std::string Path::getPackageFromPath(const std::string& path)
 {
     fs::path source(path);
-    fs::path package(utils::Path::path().getPackagesDir());
+    fs::path package(vle::utils::Path::path().getBinaryPackagesDir());
 
     fs::path::iterator it = source.begin();
     fs::path::iterator jt = package.begin();
@@ -624,11 +298,11 @@ void Path::initVleHomeDirectory()
 {
     boost::system::error_code ec;
 
-    fs::path pkgs = getPackagesDir();
+    fs::path pkgs = getBinaryPackagesDir();
 
 #if BOOST_VERSION > 104500
     if (not fs::exists(pkgs, ec)) {
-        if (not fs::create_directories(getPackagesDir(), ec)) {
+        if (not fs::create_directories(getBinaryPackagesDir(), ec)) {
             throw FileError(fmt(
                     _("Failed to build VLE_HOME directory (%1%):\n%2%")) %
                 pkgs.string() % ec.message());
@@ -715,19 +389,7 @@ Path::Path()
 {
     initHomeDir();
     initPrefixDir();
-
-    updateDirs();
-
     initVleHomeDirectory();
-}
-
-void Path::updateDirs()
-{
-    if (utils::Package::package().name().empty()) {
-        initGlobalPluginDirs();
-    } else {
-        initPackagePluginDirs();
-    }
 }
 
 void Path::clearPluginDirs()
@@ -736,71 +398,6 @@ void Path::clearPluginDirs()
     m_stream.clear();
     m_output.clear();
     m_modeling.clear();
-}
-
-void Path::initGlobalPluginDirs()
-{
-    assert(utils::Package::package().name().empty());
-
-    clearPluginDirs();
-    m_currentPackagePath.clear();
-    m_currentPackageSourcePath.clear();
-}
-
-void Path::initPackagePluginDirs()
-{
-    assert(not utils::Package::package().name().empty());
-
-    clearPluginDirs();
-
-    {
-        fs::path binary = m_home;
-        binary /= pkgdirname;
-        binary /= utils::Package::package().name();
-
-        m_currentPackagePath = binary.string();
-    }
-
-    {
-        fs::path src = fs::current_path();
-        src /= utils::Package::package().name();
-
-        m_currentPackageSourcePath = src.string();
-    }
-
-    PathList result;
-    for (fs::directory_iterator it(getPackagesDir()), end; it != end; ++it) {
-        if (fs::is_directory(it->status())) {
-            fs::path package(*it);
-            package /= "plugins";
-            if (fs::is_directory(package)) {
-                {
-                    fs::path oov(package);
-                    oov = oov /  "output";
-
-                    if (fs::is_directory(oov)) {
-                        addStreamDir(oov.string());
-                    }
-                }
-                {
-                    fs::path gvleout(package);
-                    gvleout = gvleout / "gvle" / "output";
-
-                    if (fs::is_directory(gvleout)) {
-                        addOutputDir(gvleout.string());
-                    }
-                }
-                {
-                    fs::path gvlemod(package);
-                    gvlemod = gvlemod / "gvle" /  "output";
-
-                    if (fs::is_directory(gvlemod)) {
-                        addModelingDir(gvlemod.string());
-                    }
-                }
-            }
-        }
-    }
 }
 
 std::ostream& operator<<(std::ostream& out, const PathList& paths)
@@ -1044,24 +641,8 @@ std::ostream& operator<<(std::ostream& out, const Path& p)
         << "glade.................: " << p.getGladeDir() << "\n"
         << "\n"
         << "vle home..............: " << p.getHomeDir() << "\n"
-        << "packages..............: " << p.getPackagesDir() << "\n"
+        << "packages..............: " << p.getBinaryPackagesDir() << "\n"
         << "\n";
-
-    out << "Package dir...........: " << p.getPackageSourceDir() << "\n"
-        << "Package binary dir....: " << p.getPackageBinaryDir() << "\n"
-        << "Package lib dir.......: " << p.getPackageLibDir() << "\n"
-        << "Package scr dir.......: " << p.getPackageSrcDir() << "\n"
-        << "Package data dir......: " << p.getPackageDataDir() << "\n"
-        << "Package doc dir.......: " << p.getPackageDocDir() << "\n"
-        << "Package exp dir.......: " << p.getPackageExpDir() << "\n"
-        << "Package build dir.....: " << p.getPackageBuildDir() << "\n"
-        << "Package simulators....: " << p.getPackagePluginSimulatorDir() << "\n"
-        << "Package stream........: " << p.getPackagePluginOutputDir() << "\n"
-        << "Package gvle output...: " << p.getPackagePluginGvleOutputDir()
-        << "\n"
-        << "Package gvle modeling.: " << p.getPackagePluginGvleModelingDir()
-        << "\n" << "\n";
-
     out << "Real simulators list..:\n" << p.getSimulatorDirs() << "\n"
         << "Real output list......:\n" << p.getOutputDirs() << "\n"
         << "Real modeling list....:\n" << p.getModelingDirs() << "\n"

--- a/src/vle/utils/Path.hpp
+++ b/src/vle/utils/Path.hpp
@@ -60,11 +60,6 @@ typedef std::vector < std::string > PathList;
 class VLE_API Path
 {
 public:
-    /**
-     * Rebuild path lists of plug-ins directories (package mode,
-     * global mode etc.).
-     */
-    void updateDirs();
 
     /**
      * Return the prefix of the compilation on Unix or installation
@@ -119,84 +114,12 @@ public:
      * Return the $VLE_HOME/packages dirname.
      * @return A string.
      */
-    std::string getPackagesDir() const;
 
-    /**
-     * Return the $VLE_HOME/packages/current_package dirname.
-     * @return A string.
-     */
-    std::string getPackageSourceDir() const; // TODO returns source directory : current path + package
-    std::string getPackageBinaryDir() const; // TODO returns binary directory : $VLE_HOME/pkgs-1.1 + package
-    std::string getPackageLibDir() const;
-    std::string getPackageSrcDir() const;
-    std::string getPackageDataDir() const;
-    std::string getPackageDocDir() const;
-    std::string getPackageExpDir() const;
-    std::string getPackageBuildDir() const; // TODO check current path + package + buildvle
-    std::string getPackageOutputDir() const;
-    std::string getPackagePluginDir() const;
-    std::string getPackagePluginSimulatorDir() const;
-    std::string getPackagePluginOutputDir() const;
-    std::string getPackagePluginGvleGlobalDir() const;
-    std::string getPackagePluginGvleModelingDir() const;
-    std::string getPackagePluginGvleOutputDir() const;
+    std::string getBinaryPackagesDir() const;
+    std::string getCurrentDir() const;
 
-    std::string getPackageFile(const std::string& name) const;
-    std::string getPackageLibFile(const std::string& name) const;
-    std::string getPackageSrcFile(const std::string& name) const;
-    std::string getPackageDataFile(const std::string& name) const;
-    std::string getPackageDocFile(const std::string& name) const;
-    std::string getPackageExpFile(const std::string& name) const;
-    std::string getPackageOutputFile(const std::string& name) const;
-    std::string getPackagePluginFile(const std::string& name) const;
-    std::string getPackagePluginSimulatorFile(const std::string& name) const;
-    std::string getPackagePluginOutputFile(const std::string& name) const;
-    std::string getPackagePluginGvleModelingFile(const std::string& name) const;
-    std::string getPackagePluginGvleOutputFile(const std::string& name) const;
-
-    std::string getExternalPackageDir(const std::string& name) const;
-    std::string getExternalPackageLibDir(const std::string& name) const;
-    std::string getExternalPackageSrcDir(const std::string& name) const;
-    std::string getExternalPackageDataDir(const std::string& name) const;
-    std::string getExternalPackageDocDir(const std::string& name) const;
-    std::string getExternalPackageExpDir(const std::string& name) const;
-    std::string getExternalPackageBuildDir(const std::string& name) const;
-    std::string getExternalPackageOutputDir(const std::string& name) const;
-    std::string getExternalPackagePluginDir(const std::string& name) const;
-    std::string getExternalPackagePluginSimulatorDir(const std::string& name) const;
-    std::string getExternalPackagePluginOutputDir(const std::string& name) const;
-    std::string getExternalPackagePluginGvleGlobalDir(const std::string& name) const;
-    std::string getExternalPackagePluginGvleModelingDir(const std::string& name) const;
-    std::string getExternalPackagePluginGvleOutputDir(const std::string& name) const;
-
-    std::string getExternalPackageFile(const std::string& name,
-                                       const std::string& file) const;
-    std::string getExternalPackageLibFile(const std::string& name,
-                                          const std::string& file) const;
-    std::string getExternalPackageSrcFile(const std::string& name,
-                                          const std::string& file) const;
-    std::string getExternalPackageDataFile(const std::string& name,
-                                           const std::string& file) const;
-    std::string getExternalPackageDocFile(const std::string& name,
-                                          const std::string& file) const;
-    std::string getExternalPackageExpFile(const std::string& name,
-                                          const std::string& file) const;
-    std::string getExternalPackageOutputFile(const std::string& package,
-                                             const std::string& file) const;
-    std::string getExternalPackagePluginFile(const std::string& package,
-                                             const std::string& file) const;
-    std::string getExternalPackagePluginSimulatorFile(const std::string& package,
-                                                      const std::string& file) const;
-    std::string getExternalPackagePluginOutputFile(const std::string& package,
-                                                   const std::string& file) const;
-    std::string getExternalPackagePluginGvleModelingFile(const std::string& package,
-                                                         const std::string& file) const;
-    std::string getExternalPackagePluginGvleOutputFile(const std::string& package,
-                                                       const std::string& file) const;
-
-    PathList getInstalledPackages();
-    PathList getInstalledExperiments();
-    PathList getInstalledLibraries();
+    PathList getBinaryPackages();
+    PathList getBinaryLibraries();
 
 
     /**
@@ -534,8 +457,6 @@ private:
 
     std::string m_prefix; /*!< the $prefix of installation */
     std::string m_home; /*!< the $VLE_HOME */
-    std::string m_currentPackagePath; /*< the current binary package path */
-    std::string m_currentPackageSourcePath; /*< the current source path */
 
     /**
      * Build the paths from environment variables.
@@ -579,18 +500,6 @@ private:
      * Clear all plug-ins lists.
      */
     void clearPluginDirs();
-
-    /**
-     * Assign to the plug-ins directories lists paths from prefix and
-     * home directory.
-     */
-    void initGlobalPluginDirs();
-
-    /**
-     * Assign the current package path and simulator packages lists
-     * paths from prefix or vle user dir.
-     */
-    void initPackagePluginDirs();
 
     static Path* mPath; /**< The static variable Path for singleton
                            design pattern. */

--- a/src/vle/utils/details/Compress.cpp
+++ b/src/vle/utils/details/Compress.cpp
@@ -451,7 +451,6 @@ void Path::compress(const std::string& filepath,
     if (fs::exists(path)) {
         create_archive(filepath.c_str(), compressedfilepath.c_str());
     }
-
 }
 
 void Path::decompress(const std::string& compressedfilepath,

--- a/src/vle/utils/details/PackageManager.cpp
+++ b/src/vle/utils/details/PackageManager.cpp
@@ -58,7 +58,7 @@ static bool rebuild__(Packages *out)
 {
     namespace fs = boost::filesystem;
 
-    fs::path pkgsdir(utils::Path::path().getPackagesDir());
+    fs::path pkgsdir(utils::Path::path().getBinaryPackagesDir());
     PackageParser parser;
 
     if (fs::exists(pkgsdir) and fs::is_directory(pkgsdir)) {

--- a/src/vle/utils/test/test_package.cpp
+++ b/src/vle/utils/test/test_package.cpp
@@ -195,9 +195,8 @@ BOOST_AUTO_TEST_CASE(show_path)
     fs::current_path(tmp);
 #endif
 
-
-    Package::package().select("x");
-    vle::utils::Package::package().create();
+    Package pkg("x");
+    pkg.create();
 }
 
 BOOST_AUTO_TEST_CASE(show_package)
@@ -227,16 +226,12 @@ BOOST_AUTO_TEST_CASE(show_package)
     fs::current_path(tmp);
 #endif
 
-    std::cout << "Current path: " << fs::current_path() << "\n";
-    vle::utils::Package::package().refresh();
-    vle::utils::Package::package().select("tmp");
-    vle::utils::Package::package().create();
-    std::cout << "package configure\n";
-    vle::utils::Package::package().configure();
-    std::cout << "package build\n";
-    vle::utils::Package::package().build();
-    std::cout << "package install\n";
-    vle::utils::Package::package().install();
+    Package pkg("tmp");
+
+    pkg.create();
+    pkg.configure();
+    pkg.build();
+    pkg.install();
 
     /* We need to ensure each file really installed. */
 #ifdef _WIN32
@@ -246,13 +241,14 @@ BOOST_AUTO_TEST_CASE(show_package)
 #endif
 
     std::cout << "Installed packages:\n";
-    PathList lst = Path::path().getInstalledPackages();
+    PathList lst = Path::path().getBinaryPackages();
     std::copy(lst.begin(), lst.end(), std::ostream_iterator < std::string >(
                   std::cout, "\n"));
 
-    if (not fs::exists(Path::path().getPackageExpDir())) {
-        std::cout << "Installed vpz:\n";
-        PathList vpz = Path::path().getInstalledExperiments();
+
+    if (not fs::exists(pkg.getExpDir(vle::utils::PKG_BINARY))) {
+        std::cout << "Installed vpz  :\n";
+        PathList vpz = pkg.getExperiments();
         std::copy(vpz.begin(), vpz.end(), std::ostream_iterator < std::string >(
                 std::cout, "\n"));
     }
@@ -275,6 +271,7 @@ BOOST_AUTO_TEST_CASE(remote_package_check_2_package_tmp_and_x)
         rmt.start(utils::REMOTE_MANAGER_LOCAL_SEARCH, ".*", NULL);
         rmt.join();
         rmt.getResult(&results);
+
         BOOST_REQUIRE_EQUAL(results.empty(), false);
         BOOST_REQUIRE_EQUAL(results.size(), 1u); /* We only build the tmp
                                                     package, not x. */
@@ -505,10 +502,10 @@ BOOST_AUTO_TEST_CASE(test_compress_filepath)
         fs::path unique = "check";
 #endif
 
-        vle::utils::Package::package().select(unique.string());
-        vle::utils::Package::package().create();
+        vle::utils::Package pkg(unique.string());
+        pkg.create();
 
-        filepath = vle::utils::Path::path().getPackageSourceDir();
+        filepath = pkg.getSrcDir(vle::utils::PKG_SOURCE);
         uniquepath = unique.string();
     } catch (...) {
         BOOST_REQUIRE(false);
@@ -523,8 +520,7 @@ BOOST_AUTO_TEST_CASE(test_compress_filepath)
 #endif
     tarfile /= "check.tar.bz2";
 
-
-    fs::current_path(vle::utils::Path::path().getPackagesDir());
+    fs::current_path(vle::utils::Path::path().getBinaryPackagesDir());
 
     BOOST_REQUIRE_NO_THROW(utils::Path::path().compress(uniquepath,
                                                         tarfile.string()));


### PR DESCRIPTION
- remove the package singleton and provide a public constructor
- make the distinction of the source and binary package in the API
  using the enum type (PKG_BINARY, PKG_SOURCE)
- add a package instance to GVLE
- add the argument curr_package to gvle modelling plugins
- output files are now generated into the current dir for vle and rvle
  and into <current_package>/output into gvle

NOTE: test_package is still failing because of the test for compression
