### PR TITLE
utils: format of the Description.txt file

### DIFF
--- a/src/vle/utils/details/PackageParser.cpp
+++ b/src/vle/utils/details/PackageParser.cpp
@@ -134,7 +134,7 @@ class DescriptionParser
             return false;
 
         char c = get();
-        if (!isalpha(c)) /* check if the first character is an alpha
+        if (!isalnum(c)) /* check if the first character is an alphanum
                             character */
             return false;
 


### PR DESCRIPTION
The id of a package  in the description files is required to be an alpha
character. Instead, one should use the isalnum function (Cloases #118).
