### PR TITLE
devs: add a runtimes access to the results

### DIFF
--- a/src/vle/devs/RootCoordinator.cpp
+++ b/src/vle/devs/RootCoordinator.cpp
@@ -133,4 +133,13 @@ void RootCoordinator::finish()
     }
 }
 
+value::Map * RootCoordinator::runtimeOutputs()
+{
+     if (m_coordinator) {
+         return getMatrixFromView(m_coordinator->getViews());
+     }
+
+     return 0;
+}
+
 }} // namespace vle devs

--- a/src/vle/devs/RootCoordinator.hpp
+++ b/src/vle/devs/RootCoordinator.hpp
@@ -84,6 +84,16 @@ namespace vle { namespace devs {
         void finish();
 
         /**
+         * Return an allocated \c value::Map.
+         *
+         * This function build a new \c value::Matrix based on the
+         * observation of the simulation. This function can return
+         * NULL if there is no storage view.
+         * @return  Return a constant reference to the list of view plugins.
+         */
+        value::Map * runtimeOutputs();
+
+        /**
          * @brief Return the current time of the simulation.
          * @return A constant reference to the current time.
          */
@@ -95,8 +105,7 @@ namespace vle { namespace devs {
          *
          * This function build a new \c value::Matrix based on the
          * observation of the simulation. This function can return
-         * NULL if tablea
-         constant reference to the list of view plugins.
+         * NULL if there is no storage view.
          * @return  Return a constant reference to the list of view plugins.
          */
         value::Map * outputs() { return m_result; }


### PR DESCRIPTION
A runtime access to the results has been provided to the
RootCoordinator class.
