### PR TITLE
manager: fix the experiment generator

### DIFF
--- a/src/vle/manager/ExperimentGenerator.cpp
+++ b/src/vle/manager/ExperimentGenerator.cpp
@@ -30,7 +30,6 @@
 #include <vle/vpz/Vpz.hpp>
 #include <vle/vpz/BaseModel.hpp>
 
-
 namespace vle { namespace manager {
 
 //
@@ -84,25 +83,12 @@ class ExperimentGenerator::Pimpl
         mCompleteSize = computeMaximumValue();
 
         uint32_t number = mCompleteSize / mWorld;
+        uint32_t modulo = mCompleteSize % mWorld;
 
-        if (number > 0) {
-            mMin = number * mRank;
-            mMax = number * (mRank + 1) - 1;
-
-            if (mMax > mCompleteSize) {
-                mMax = mCompleteSize;
-            }
-        } else {
-            uint32_t modulo = mCompleteSize % mWorld;
-
-            if (modulo > mRank) {
-                mMin = mRank;
-                mMax = mRank + 1;
-            } else {
-                mMin = modulo;
-                mMax = modulo;
-            }
-        }
+        mMin = (number+1) * std::min(mRank, modulo) + number *
+                uint32_t(std::max((int32_t) 0, int32_t(mRank-modulo)));
+        mMax = std::min(mCompleteSize,
+                mMin + number + 1 * uint32_t(mRank < modulo));
     }
 
 public:

--- a/src/vle/manager/Manager.cpp
+++ b/src/vle/manager/Manager.cpp
@@ -145,7 +145,7 @@ public:
         {
             std::string vpzname(vpz->project().experiment().name());
 
-            for (uint32_t i = expgen.min() + index; i <= expgen.max();
+            for (uint32_t i = expgen.min() + index; i < expgen.max();
                  i += threads) {
                 Simulation sim(mLogOption, mSimulationOption, NULL);
                 Error err;
@@ -209,8 +209,8 @@ public:
         error->code = 0;
         error->message.clear();
 
-        if (mSimulationOption & manager::SIMULATION_NO_RETURN) {
-            for (uint32_t i = expgen.min(); i <= expgen.max(); ++i) {
+        if (mSimulationOption == manager::SIMULATION_NO_RETURN) {
+            for (uint32_t i = expgen.min(); i < expgen.max(); ++i) {
                 Error err;
                 vpz::Vpz *file = new vpz::Vpz(*vpz);
                 setExperimentName(file, vpzname, i);
@@ -230,7 +230,7 @@ public:
         } else {
             result = new value::Matrix(expgen.size(), 1, expgen.size(), 1);
 
-            for (uint32_t i = expgen.min(); i <= expgen.max(); ++i) {
+            for (uint32_t i = expgen.min(); i < expgen.max(); ++i) {
                 Error err;
                 vpz::Vpz *file = new vpz::Vpz(*vpz);
                 setExperimentName(file, vpzname, i);

--- a/src/vle/manager/test/test1.cpp
+++ b/src/vle/manager/test/test1.cpp
@@ -122,17 +122,17 @@ BOOST_AUTO_TEST_CASE(experimentgenerator_lower_than_exp)
 
     manager::ExperimentGenerator expgen1(vpz, 0, 100);
     BOOST_CHECK_EQUAL(expgen1.min(), 0);
-    BOOST_CHECK_EQUAL(expgen1.max(), 99);
+    BOOST_CHECK_EQUAL(expgen1.max(), 100);
     BOOST_CHECK_EQUAL(expgen1.size(), 10000);
 
     manager::ExperimentGenerator expgen2(vpz, 99, 100);
     BOOST_CHECK_EQUAL(expgen2.min(), 9900);
-    BOOST_CHECK_EQUAL(expgen2.max(), 9999);
+    BOOST_CHECK_EQUAL(expgen2.max(), 10000);
     BOOST_CHECK_EQUAL(expgen2.size(), 10000);
 
     manager::ExperimentGenerator expgen3(vpz, 50, 100);
     BOOST_CHECK_EQUAL(expgen3.min(), 5000);
-    BOOST_CHECK_EQUAL(expgen3.max(), 5099);
+    BOOST_CHECK_EQUAL(expgen3.max(), 5100);
     BOOST_CHECK_EQUAL(expgen3.size(), 10000);
 }
 
@@ -221,6 +221,6 @@ BOOST_AUTO_TEST_CASE(experimentgenerator_max_1_max_1)
 
     manager::ExperimentGenerator expgen1(vpz, 0, 1);
     BOOST_CHECK_EQUAL(expgen1.min(), 0);
-    BOOST_CHECK_EQUAL(expgen1.max(), 6);
+    BOOST_CHECK_EQUAL(expgen1.max(), 7);
     BOOST_CHECK_EQUAL(expgen1.size(), 7);
 }


### PR DESCRIPTION
- all simulations were not performed due to an error on allocation of
  simulations to different ranks (Closes #145).
- the max index of the experiment generator is now excluded from
  the simulations to perform for a given rank (the behavior is now the same
  between mvle and the manager). Tests are updated.
