### PR TITLE
vpz: set duration and begin into the conditions

### DIFF
--- a/share/dtd/CMakeLists.txt
+++ b/share/dtd/CMakeLists.txt
@@ -1,2 +1,3 @@
 INSTALL(FILES vle-0.5.0.dtd vle-0.6.0.dtd vle-0.7.0.dtd vle-0.8.0.dtd
-  vle-0.9.0.dtd vle-1.0.0.dtd vle-1.1.0.dtd DESTINATION "${VLE_SHARE_DIRS}/dtd")
+  vle-0.9.0.dtd vle-1.0.0.dtd vle-1.1.0.dtd vle-1.2.0.dtd 
+  DESTINATION "${VLE_SHARE_DIRS}/dtd")

--- a/share/dtd/vle-1.2.0.dtd
+++ b/share/dtd/vle-1.2.0.dtd
@@ -1,0 +1,124 @@
+<!ELEMENT vle_project (structures?, dynamics?, classes?, experiment) >
+<!ELEMENT structures (model?) >
+<!ELEMENT model (in?, out?, submodels?, connections?) >
+<!ELEMENT in (port*) >
+<!ELEMENT out (port*) >
+<!ELEMENT submodels (model*) >
+<!ELEMENT connections (connection*) >
+<!ELEMENT connection (origin, destination) >
+<!ELEMENT origin EMPTY >
+<!ELEMENT destination EMPTY >
+<!ELEMENT dynamics (dynamic*) >
+<!ELEMENT dynamic EMPTY >
+<!ELEMENT classes (class*) >
+<!ELEMENT class (model?) >
+<!ELEMENT experiment (conditions?, views?) >
+<!ELEMENT conditions (condition*) >
+<!ELEMENT condition (port*) >
+<!ELEMENT port ((attachedview*)|(integer|double|boolean|string|table|tuple|set|matrix|map|xml|null)*) >
+<!ELEMENT views (outputs, observables, view*) >
+<!ELEMENT outputs (output*) >
+<!ELEMENT output (integer?|double?|boolean?|string?|table?|tuple?|set?|matrix?|map?|xml?|null?) >
+<!ELEMENT observables (observable*) >
+<!ELEMENT observable (port*) >
+<!ELEMENT attachedview EMPTY >
+<!ELEMENT view (#PCDATA) >
+<!ELEMENT integer (#PCDATA) >
+<!ELEMENT double (#PCDATA) >
+<!ELEMENT boolean (#PCDATA) >
+<!ELEMENT string (#PCDATA) >
+<!ELEMENT table (#PCDATA) >
+<!ELEMENT tuple (#PCDATA) >
+<!ELEMENT set (integer|double|boolean|string|table|tuple|set|matrix|map|xml|null)* >
+<!ELEMENT matrix (integer|double|boolean|string|table|tuple|set|matrix|map|xml|null) >
+<!ELEMENT map (key*) >
+<!ELEMENT key (integer|double|boolean|string|table|tuple|set|matrix|map|xml|null) >
+<!ELEMENT xml (#PCDATA) >
+
+<!ATTLIST vle_project
+  date CDATA #IMPLIED
+  version CDATA #REQUIRED
+  instance CDATA #IMPLIED
+  replica CDATA #IMPLIED
+  author CDATA #REQUIRED >
+
+<!ATTLIST model
+  name CDATA #REQUIRED
+  type (atomic|coupled) #REQUIRED
+  dynamics CDATA #IMPLIED
+  conditions CDATA #IMPLIED
+  observables CDATA #IMPLIED
+  x CDATA #IMPLIED
+  y CDATA #IMPLIED
+  width CDATA #IMPLIED
+  height CDATA #IMPLIED >
+
+<!ATTLIST port
+  name CDATA #REQUIRED >
+
+<!ATTLIST connection
+  type (input|output|internal) #REQUIRED >
+
+<!ATTLIST origin
+  model CDATA #REQUIRED
+  port CDATA #REQUIRED >
+
+<!ATTLIST destination
+  model CDATA #REQUIRED
+  port CDATA #REQUIRED >
+
+<!ATTLIST dynamic
+  name CDATA #REQUIRED
+  library CDATA #REQUIRED
+  package CDATA #IMPLIED
+  location CDATA #IMPLIED
+  type CDATA #IMPLIED
+  language CDATA #IMPLIED >
+
+<!ATTLIST class
+  name CDATA #REQUIRED >
+
+<!ATTLIST experiment
+  name CDATA #REQUIRED
+  combination (linear|total) #IMPLIED >
+
+<!ATTLIST condition
+  name CDATA #REQUIRED >
+
+<!ATTLIST output
+  name CDATA #REQUIRED
+  format (local|distant) #REQUIRED
+  location CDATA #IMPLIED
+  package CDATA #IMPLIED
+  plugin CDATA #REQUIRED >
+
+<!ATTLIST observable
+  name CDATA #REQUIRED >
+
+<!ATTLIST attachedview
+  name CDATA #REQUIRED >
+
+<!ATTLIST view
+  name CDATA #REQUIRED
+  type (timed|event|finish) #REQUIRED
+  output CDATA #REQUIRED
+  timestep CDATA #IMPLIED >
+
+<!ATTLIST table
+  width CDATA #REQUIRED
+  height CDATA #REQUIRED >
+
+<!ATTLIST key
+  name CDATA #REQUIRED >
+
+<!ATTLIST matrix
+  rows CDATA #REQUIRED
+  columns CDATA #REQUIRED
+  rowmax CDATA #IMPLIED
+  columnmax CDATA #IMPLIED
+  rowstep CDATA #IMPLIED
+  columnstep CDATA #IMPLIED >
+
+<!--
+vim:ts=8:tw=160:sw=2:sts=2
+-->

--- a/share/template/package/exp/empty.vpz
+++ b/share/template/package/exp/empty.vpz
@@ -5,6 +5,16 @@
  </structures>
  <dynamics>
  </dynamics>
-  <experiment name="test" begin="0.0" duration="1.0" seed="123456789">
+  <experiment name="test" seed="123456789">
+   <conditions>
+    <condition name="simulation_engine" >
+     <port name="begin" >
+      <double>0.0</double>
+     </port>
+     <port name="duration" >
+      <double>1.0</double>
+     </port>"
+    </condition>
+   </conditions>
   </experiment>
 </vle_project>

--- a/share/template/unittest.vpz
+++ b/share/template/unittest.vpz
@@ -278,8 +278,16 @@
    </model>
   </class>
  </classes>
- <experiment name="graphtester" duration="100.000000000000000" begin="0.000000000000000" seed="123" >
+ <experiment name="graphtester" seed="123" >
   <conditions>
+   <condition name="simulation_engine" >
+    <port name="begin" >
+     <double>0.0</double>
+    </port>
+    <port name="duration" >
+     <double>100.0</double>
+    </port>
+   </condition>
    <condition name="ca" >
     <port name="x" >
      <double>1.200000000000000</double>

--- a/src/vle/vpz/Conditions.cpp
+++ b/src/vle/vpz/Conditions.cpp
@@ -82,14 +82,9 @@ void Conditions::add(const Conditions& cdts)
 
 Condition& Conditions::add(const Condition& condition)
 {
+    del(condition.name());
     std::pair < iterator, bool > x;
     x = m_list.insert(value_type(condition.name(), condition));
-
-    if (not x.second) {
-        throw utils::ArgError(fmt(
-                _("The condition '%1%' already exists")) % condition.name());
-    }
-
     return x.first->second;
 }
 

--- a/src/vle/vpz/Conditions.hpp
+++ b/src/vle/vpz/Conditions.hpp
@@ -136,10 +136,8 @@ namespace vpz {
         /**
          * @brief Add a condition into the conditions list.
          * @param condition the condition to add into the map. Condition is
-         * copied.
+         * copied, replace the condition if it already exists
          * @return the newly created Condition.
-         * @throw utils::ArgError if condition with same name and port already
-         * exist.
          */
         Condition& add(const Condition& condition);
 

--- a/src/vle/vpz/Experiment.cpp
+++ b/src/vle/vpz/Experiment.cpp
@@ -26,15 +26,23 @@
 
 
 #include <vle/vpz/Experiment.hpp>
+#include <vle/value/Double.hpp>
+#include <vle/value/Set.hpp>
 
 namespace vle { namespace vpz {
+
+Experiment::Experiment()
+{
+    Condition cond(defaultSimulationEngineCondName());
+    cond.addValueToPort("begin", new vle::value::Double(0));
+    cond.addValueToPort("duration", new vle::value::Double(1));
+    conditions().add(cond);
+}
 
 void Experiment::write(std::ostream& out) const
 {
     out << "<experiment "
-        << "name=\"" << m_name.c_str() << "\" "
-        << "duration=\"" << m_duration << "\" "
-        << "begin=\"" << m_begin << "\" ";
+        << "name=\"" << m_name.c_str() << "\" ";
 
     if (not m_combination.empty()) {
         out << "combination=\"" << m_combination.c_str()
@@ -52,8 +60,6 @@ void Experiment::write(std::ostream& out) const
 void Experiment::clear()
 {
     m_name.clear();
-    m_duration = 1.0;
-    m_begin = 0;
 
     m_conditions.clear();
     m_views.clear();
@@ -78,20 +84,58 @@ void Experiment::setName(const std::string& name)
     m_name.assign(name);
 }
 
+void Experiment::setDuration(double duration)
+{
+    if (not conditions().exist(defaultSimulationEngineCondName())) {
+        throw utils::ArgError(_("The simulation engine condition"
+                "does not exist"));
+    }
+    vle::vpz::Condition& condSim = conditions().get(
+            defaultSimulationEngineCondName());
+    vle::value::Set& dur = condSim.getSetValues("duration");
+    dur.clear();
+    dur.add(new vle::value::Double(duration));
+}
+
+double Experiment::duration() const
+{
+    if (not conditions().exist(defaultSimulationEngineCondName())) {
+        throw utils::ArgError(_("The simulation engine condition"
+                "does not exist"));
+    }
+    const vle::vpz::Condition& condSim = conditions().get(
+            defaultSimulationEngineCondName());
+    return condSim.getSetValues("duration").getDouble(0);
+}
+
+void Experiment::setBegin(double begin)
+{
+    if (not conditions().exist(defaultSimulationEngineCondName())) {
+        throw utils::ArgError(_("The simulation engine condition"
+                "does not exist"));
+    }
+    vle::vpz::Condition& condSim = conditions().get(
+            defaultSimulationEngineCondName());
+    vle::value::Set& dur = condSim.getSetValues("begin");
+    dur.clear();
+    dur.add(new vle::value::Double(begin));
+}
+
+double Experiment::begin() const
+{
+    if (not conditions().exist(defaultSimulationEngineCondName())) {
+        throw utils::ArgError(_("The simulation engine condition"
+                "does not exist"));
+    }
+    const vle::vpz::Condition& condSim = conditions().get(
+            defaultSimulationEngineCondName());
+    return condSim.getSetValues("begin").getDouble(0);
+}
+
 void Experiment::cleanNoPermanent()
 {
     m_conditions.cleanNoPermanent();
     m_views.observables().cleanNoPermanent();
-}
-
-void Experiment::setDuration(double duration)
-{
-    if (duration <= 0.0) {
-        throw utils::ArgError(fmt(
-                _("Experiment duration error: %1% (must be > 0)")) % duration);
-    }
-
-    m_duration = duration;
 }
 
 void Experiment::setCombination(const std::string& name)

--- a/src/vle/vpz/Experiment.hpp
+++ b/src/vle/vpz/Experiment.hpp
@@ -42,13 +42,13 @@ namespace vle { namespace vpz {
     class VLE_API Experiment : public Base
     {
     public:
+
         /**
          * Build an empty experiment with time duration of 1.0 and beginning
          * date at 0.0.
+         * Add the default condition for simulation engine
          */
-        Experiment()
-            : m_duration(1.0), m_begin(0.0)
-        {}
+        Experiment();
 
         /**
          * @brief Nothing to delete.
@@ -165,22 +165,19 @@ namespace vle { namespace vpz {
          * @brief Get the duration of the Experiment file.
          * @return The duration.
          */
-        double duration() const
-        { return m_duration; }
+        double duration() const;
 
         /**
          * @brief Assign a new beginning date to the simulation.
          * @param begin The new beginning date of the simulation.
          */
-        void setBegin(const double& begin)
-        { m_begin = begin; }
+        void setBegin(double begin);
 
         /**
          * @brief Get the beginning date of the simulation.
          * @return A real [0.0..max double[
          */
-        const double& begin() const
-        { return m_begin; }
+        double begin() const;
 
         /**
          * @brief Set the experimental design combination.
@@ -196,9 +193,17 @@ namespace vle { namespace vpz {
         { return m_combination; }
 
     private:
+
+        /**
+         * @brief get the default engine simulation condition name
+         * @return the default engine simulation condition name
+         */
+        static std::string defaultSimulationEngineCondName()
+        {
+            return "simulation_engine";
+        }
+
         std::string         m_name;
-        double              m_duration;
-        double              m_begin;
         std::string         m_combination;
         Conditions          m_conditions;
         Views               m_views;

--- a/src/vle/vpz/SaxStackVpz.cpp
+++ b/src/vle/vpz/SaxStackVpz.cpp
@@ -513,39 +513,23 @@ void SaxStackVpz::pushExperiment(const xmlChar** att)
         throw utils::SaxParserError();
     }
 
+
+
     vpz::Experiment& exp(m_vpz.project().experiment());
     push(&exp);
 
     const xmlChar* name = 0;
-    const xmlChar* duration = 0;
-    const xmlChar* begin = 0;
     const xmlChar* combination = 0;
 
     for (int i = 0; att[i] != 0; i += 2) {
         if (xmlStrcmp(att[i], (const xmlChar*)"name") == 0) {
             name = att[i + 1];
-        } else if (xmlStrcmp(att[i], (const xmlChar*)"duration") == 0) {
-            duration = att[i + 1];
-        } else if (xmlStrcmp(att[i], (const xmlChar*)"begin") == 0) {
-            begin = att[i + 1];
         } else if (xmlStrcmp(att[i], (const xmlChar*)"combination") == 0) {
             combination = att[i + 1];
         }
     }
 
-    if (not name or not duration) {
-        throw utils::SaxParserError(
-            _("Experiment tag does not have 'name' or 'duration' attributes"));
-    }
-
     exp.setName(xmlCharToString(name));
-    exp.setDuration(xmlCharToDouble(duration));
-
-    if (begin) {
-        exp.setBegin(xmlCharToDouble(begin));
-    } else {
-        exp.setBegin(0.0);
-    }
 
     if (combination) {
         exp.setCombination(xmlCharToString(combination));

--- a/src/vle/vpz/test/test2.cpp
+++ b/src/vle/vpz/test/test2.cpp
@@ -204,8 +204,16 @@ BOOST_AUTO_TEST_CASE(experiment_vpz)
         "<?xml version=\"1.0\"?>\n"
         "<vle_project version=\"0.5\" author=\"Gauthier Quesnel\""
         " date=\"Mon, 12 Feb 2007 23:40:31 +0100\" >\n"
-        " <experiment name=\"test1\" duration=\"0.33\" >\n"
+        " <experiment name=\"test1\" duration=\"0.33\">\n"
         "  <conditions>"
+        "   <condition name=\"simulation_engine\" >"
+        "    <port name=\"begin\" >"
+        "     <double>123.</double>"
+        "    </port>"
+        "    <port name=\"duration\" >"
+        "     <double>0.33</double><integer>2</integer>"
+        "    </port>"
+        "   </condition>"
         "   <condition name=\"cond1\" >"
         "    <port name=\"init1\" >"
         "     <double>123.</double><integer>1</integer>"
@@ -238,9 +246,9 @@ BOOST_AUTO_TEST_CASE(experiment_vpz)
 
     std::list < std::string > lst;
     cnds.conditionnames(lst);
-    BOOST_REQUIRE_EQUAL(lst.size(), (std::list < std::string >::size_type)2);
+    BOOST_REQUIRE_EQUAL(lst.size(), (std::list < std::string >::size_type)3);
     BOOST_REQUIRE_EQUAL(*lst.begin(), "cond1");
-    BOOST_REQUIRE_EQUAL(*lst.rbegin(), "cond2");
+    BOOST_REQUIRE_EQUAL(*lst.rbegin(), "simulation_engine");
     lst.clear();
 
     cnds.portnames("cond1", lst);

--- a/src/vle/vpz/test/test4.cpp
+++ b/src/vle/vpz/test/test4.cpp
@@ -639,6 +639,7 @@ BOOST_AUTO_TEST_CASE(test_remove_dyns)
     check_remove_dyns_unittest_vpz(proj);
 
     std::string str(vpz.writeToString());
+
     delete vpz.project().model().model();
     vpz.clear();
 


### PR DESCRIPTION
In order to use the begin and duration into experiment plans, these are
moved from experiment settings to conditions (Closes #143).
Add a vle-1.2.0.dtd file.
Update template package by adding default simulation engine condition.
Update tests into vpz.
