### PR TITLE
gvle: enlarge the gvle API (in order also to provide the vle.ibm package)

### DIFF
--- a/src/vle/gvle/FileTreeView.cpp
+++ b/src/vle/gvle/FileTreeView.cpp
@@ -862,4 +862,10 @@ void FileTreeView::removeFiles(const Gtk::TreeModel::Row* parent,
     }
 }
 
+std::string FileTreeView::getSelected()
+{
+    Gtk::TreeModel::iterator it = mTreeModel->get_iter(mRecentSelectedPath);
+    return mParent->currentPackage().
+        getExpFile((*it).get_value(mColumns.mColname), vle::utils::PKG_SOURCE);
+}
 }} // namespace vle gvle

--- a/src/vle/gvle/FileTreeView.hpp
+++ b/src/vle/gvle/FileTreeView.hpp
@@ -28,6 +28,7 @@
 #ifndef VLE_GVLE_FILETREEVIEW_HPP
 #define VLE_GVLE_FILETREEVIEW_HPP
 
+#include <vle/gvle/DllDefines.hpp>
 #include <gtkmm/builder.h>
 #include <gtkmm/treeview.h>
 #include <gtkmm/treestore.h>
@@ -54,7 +55,7 @@ public:
 /**
  * @brief FileTreeView used for display file hierarchy.
  */
-class FileTreeView : public Gtk::TreeView
+class GVLE_API FileTreeView : public Gtk::TreeView
 {
 public:
     FileTreeView(BaseObjectType* cobject,
@@ -79,6 +80,12 @@ public:
 
     void setParent(GVLE* parent)
     { mParent = parent; }
+
+    Gtk::Menu& getMenuPopup(){
+        return mMenuPopup;
+    }
+
+    std::string getSelected();
 
 protected:
     bool on_button_press_event(GdkEventButton* event);

--- a/src/vle/gvle/GVLEMenuAndToolbar.hpp
+++ b/src/vle/gvle/GVLEMenuAndToolbar.hpp
@@ -28,6 +28,7 @@
 #ifndef VLE_GVLE_GVLEMENUANDTOOLBAR_HPP
 #define VLE_GVLE_GVLEMENUANDTOOLBAR_HPP
 
+#include <vle/gvle/DllDefines.hpp>
 #include <gtkmm/builder.h>
 #include <gtkmm/toolbar.h>
 #include <gtkmm/menubar.h>
@@ -42,7 +43,7 @@ class GVLE;
 /**
  * @brief A class to manage the GVLE main menu window.
  */
-class GVLEMenuAndToolbar
+class GVLE_API GVLEMenuAndToolbar
 {
 public:
     static const Glib::ustring UI_DEFINITION;

--- a/src/vle/gvle/Modeling.hpp
+++ b/src/vle/gvle/Modeling.hpp
@@ -28,6 +28,7 @@
 #ifndef GUI_MODELING_HPP
 #define GUI_MODELING_HPP
 
+#include <vle/gvle/DllDefines.hpp>
 #include <vle/vpz/Vpz.hpp>
 #include <vle/vpz/CoupledModel.hpp>
 #include <vle/utils/Rand.hpp>
@@ -47,7 +48,7 @@ class View;
  * store the vpz::Model hierarchy, the gui::GModel hierarchy and all
  * information on the project.
  */
-class Modeling
+class GVLE_API Modeling
 {
 private:
     typedef std::vector < std::pair < std::string,

--- a/src/vle/gvle/PluginFactory.hpp
+++ b/src/vle/gvle/PluginFactory.hpp
@@ -28,6 +28,7 @@
 #ifndef VLE_GVLE_PLUGINFACTORY_HPP
 #define VLE_GVLE_PLUGINFACTORY_HPP 1
 
+#include <vle/gvle/DllDefines.hpp>
 #include <vle/utils/ModuleManager.hpp>
 #include <vle/gvle/GlobalPlugin.hpp>
 #include <vle/gvle/ModelingPlugin.hpp>
@@ -41,7 +42,7 @@ namespace vle { namespace gvle {
  * The @vle::utils::ModuleManager is a no-copyable and no-assignable class to
  * avoid modules problems.
  */
-class PluginFactory
+class GVLE_API PluginFactory
 {
 public:
     /**


### PR DESCRIPTION
In order to enable more, for example when providing
a global plugin, the API is wider available.
By the way an acces to the menu of the file treeview
is provided.