### PR TITLE
gvle: fix the modeling plugin

### DIFF
--- a/src/vle/gvle/ModelingPlugin.hpp
+++ b/src/vle/gvle/ModelingPlugin.hpp
@@ -169,6 +169,8 @@ public:
 
     const std::string& getLibrary() const { return mLibrary; }
 
+    void setCurrPackage(const std::string& curr_package) { mCurrPackage = curr_package;}
+
     const std::string& getCurrPackage() const { return mCurrPackage; }
 
 protected:
@@ -193,4 +195,3 @@ typedef ModelingPlugin* (*GvleModelingPluginSlot)(const std::string&,
 }} // namespace vle gvle
 
 #endif
-

--- a/src/vle/gvle/PluginFactory.cpp
+++ b/src/vle/gvle/PluginFactory.cpp
@@ -130,6 +130,7 @@ ModelingPluginPtr PluginFactory::getModelingPlugin(
 
     if (it != mPimpl->mModelingPluginList.end()) {
         modelingPluginPtr = it->second;
+        modelingPluginPtr->setCurrPackage(curr_package);
     } else {
         GvleModelingPluginSlot fct = NULL;
 


### PR DESCRIPTION
When a modeling plugin was called once more during a work session, the
current package was not reset. And when the user did move from a
package to another this was causing trouble in the application.