### PR TITLE
A lot of patch to make VLE C++11 friendly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,11 @@ if (NOT WITH_CAIRO AND NOT WITH_GTK)
   endif ()
 endif()
 
+# Propagates -std=C++11 CC option from pkg-config but VLEDEPS_CFLAGS_OTHER
+# #seems to be a CMake'list. So we replace ';' with ' '.
+string(REPLACE ";" " " VLEDEPS_CFLAGS_OTHER_STRING "${VLEDEPS_CFLAGS_OTHER}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VLEDEPS_CFLAGS_OTHER_STRING}")
+
 if (WITH_QT)
   find_package(Qt4 REQUIRED)
   if (NOT QT_FOUND)
@@ -244,6 +249,8 @@ include_directories(${VLE_BINARY_DIR})
 # prefix=/target to detect the DIRNAME
 # cflag=-Iboost_1_34_1 for the directory
 #
+
+set(VLE_PKGCONFIG_CFLAGS_OTHER "${VLEDEPS_CFLAGS_OTHER_STRING}")
 if (UNIX)
   set(VLE_PKGCONFIG_PREFIXPATH "${CMAKE_INSTALL_PREFIX}")
   set(VLE_PKGCONFIG_BOOSTINCLUDE_DIRS "${Boost_INCLUDE_DIRS}")

--- a/src/vle/gvle/Editor.cpp
+++ b/src/vle/gvle/Editor.cpp
@@ -696,11 +696,16 @@ void Editor::createBlankNewFile(const std::string& path,
     try {
         DocumentText* doc =
             new DocumentText(mGVLE,  path + "/" + fileName, true, true);
+
+        std::string filepath(path);
+        filepath += '/';
+        filepath += fileName;
+
         mDocuments.insert(
-            std::make_pair < std::string, DocumentText* >
-            (path + "/" + fileName, doc));
-        append_page(*doc, *(addLabel(fileName,
-                                     path + "/" + fileName)));
+            std::pair<std::string, DocumentText*>(
+                filepath, doc));
+
+        append_page(*doc, *(addLabel(fileName, filepath)));
     } catch (std::exception& e) {
         Error(e.what());
     }
@@ -724,10 +729,8 @@ void Editor::createBlankNewFile()
     name = nameTmp;
     try {
         DocumentText* doc = new DocumentText(mGVLE, nameTmp, true);
-        mDocuments.insert(
-            std::make_pair < std::string, DocumentText* >(nameTmp, doc));
-        append_page(*doc, *(addLabel(doc->filename(),
-                                     nameTmp)));
+        mDocuments.insert(std::pair<std::string, DocumentText*>(nameTmp, doc));
+        append_page(*doc, *(addLabel(doc->filename(), nameTmp)));
     } catch (std::exception& e) {
         Error(e.what());
     }

--- a/src/vle/gvle/gvle.pc.in
+++ b/src/vle/gvle/gvle.pc.in
@@ -8,4 +8,4 @@ Description: GVLE the gui for VLE the multimodelling and Simulation tools
 Requires: gtkmm-2.4 cairomm-1.0 vle-@VLE_VERSION_SHORT@
 Version: @VLE_VERSION@
 Libs:	-L${libdir} @VLE_GVLE_LIBRARY@ -lvle-@VLE_VERSION_SHORT@
-Cflags: -I${includedir}/vle-@VLE_VERSION_SHORT@ -I@VLE_PKGCONFIG_BOOSTINCLUDE_DIRS@
+Cflags: -I${includedir}/vle-@VLE_VERSION_SHORT@ -I@VLE_PKGCONFIG_BOOSTINCLUDE_DIRS@ @VLE_PKGCONFIG_CFLAGS_OTHER@

--- a/src/vle/gvle2/gvle2.pc.in
+++ b/src/vle/gvle2/gvle2.pc.in
@@ -8,4 +8,4 @@ Description: GVLE2 the other gui for VLE the multimodelling and Simulation tools
 Requires: QtCore QtXml vle-@VLE_VERSION_SHORT@
 Version: @VLE_VERSION@
 Libs:	-L${libdir} @VLE2_GVLE_LIBRARY@ -lvle-@VLE_VERSION_SHORT@
-Cflags: -I${includedir}/vle-@VLE_VERSION_SHORT@ -I@VLE_PKGCONFIG_BOOSTINCLUDE_DIRS@
+Cflags: -I${includedir}/vle-@VLE_VERSION_SHORT@ -I@VLE_PKGCONFIG_BOOSTINCLUDE_DIRS@ @VLE_PKGCONFIG_CFLAGS_OTHER@

--- a/src/vle/utils/ModuleManager.cpp
+++ b/src/vle/utils/ModuleManager.cpp
@@ -401,7 +401,7 @@ public:
 
             if (result) {
                 mLst.insert(
-                    std::make_pair < std::string, void* >(symbol, result));
+                    std::pair<std::string, void*>(symbol, result));
                 return result;
             } else {
                 throw utils::InternalError(fmt(
@@ -507,7 +507,7 @@ public:
                 return it->second;
             } else {
                 return mTableSimulator.insert(
-                    std::make_pair < std::string, pimpl::Module* >(
+                    std::pair<std::string, pimpl::Module*>(
                         path, new pimpl::Module(path, package, library,
                                                 type))).first->second;
             }
@@ -518,7 +518,7 @@ public:
                 return it->second;
             } else {
                 return mTableOov.insert(
-                    std::make_pair < std::string, pimpl::Module* >(
+                    std::pair<std::string, pimpl::Module*>(
                         path, new pimpl::Module(path, package, library,
                                                 type))).first->second;
             }
@@ -529,7 +529,7 @@ public:
                 return it->second;
             } else {
                 return mTableGvleGlobal.insert(
-                    std::make_pair < std::string, pimpl::Module* >(
+                    std::pair<std::string, pimpl::Module*>(
                         path, new pimpl::Module(path, package, library,
                                                 type))).first->second;
             }
@@ -540,7 +540,7 @@ public:
                 return it->second;
             } else {
                 return mTableGvleModeling.insert(
-                    std::make_pair < std::string, pimpl::Module* >(
+                    std::pair<std::string, pimpl::Module*>(
                         path, new pimpl::Module(path, package, library,
                                                 type))).first->second;
             }
@@ -551,7 +551,7 @@ public:
                 return it->second;
             } else {
                 return mTableGvleOutput.insert(
-                    std::make_pair < std::string, pimpl::Module* >(
+                    std::pair<std::string, pimpl::Module*>(
                         path, new pimpl::Module(path, package, library,
                                                 type))).first->second;
             }

--- a/src/vle/vle.pc.in
+++ b/src/vle/vle.pc.in
@@ -8,4 +8,4 @@ Description: VLE multimodelling and Simulation tools
 Requires: libxml-2.0 glibmm-2.4
 Version: @VLE_VERSION@
 Libs:	-L${libdir} -lvle-@VLE_VERSION_SHORT@
-Cflags: -I${includedir}/vle-@VLE_VERSION_SHORT@ -I@VLE_PKGCONFIG_BOOSTINCLUDE_DIRS@
+Cflags: -I${includedir}/vle-@VLE_VERSION_SHORT@ -I@VLE_PKGCONFIG_BOOSTINCLUDE_DIRS@ @VLE_PKGCONFIG_CFLAGS_OTHER@


### PR DESCRIPTION
Patchs to compile VLE with `-std=c++11` c++/clang++ cflags.
A patch to propagate the additional cxxflags from pkg-config to vle's pkg-config script.