### PR TITLE
utils: fix the DateTime format

### DIFF
--- a/src/vle/utils/DateTime.cpp
+++ b/src/vle/utils/DateTime.cpp
@@ -30,6 +30,7 @@
 #include <boost/date_time.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/date_time/posix_time/posix_time_io.hpp>
 #include <sstream>
 #include <cmath>
 
@@ -227,7 +228,14 @@ std::string DateTime::toJulianDay(double date)
 
     boost::posix_time::time_duration td(hours, minutes, seconds, f);
     boost::posix_time::ptime d(boost::gregorian::date(e), td);
-    return boost::posix_time::to_simple_string(d);
+
+    std::stringstream ss;
+    boost::posix_time::time_facet* facet = new boost::posix_time::time_facet();
+    facet->format("%Y-%m-%d %H:%M:%S");
+    ss.imbue(std::locale(std::locale::classic(), facet));
+    ss << d;
+    return ss.str();
+    //return boost::posix_time::to_simple_string(d);
 }
 
 double DateTime::toJulianDay(const std::string& date)

--- a/src/vle/utils/DateTime.hpp
+++ b/src/vle/utils/DateTime.hpp
@@ -242,7 +242,7 @@ public:
     /**
      * @brief Convert a julian date into a string.
      * @code
-     * vle::utils::DateTime::toJulianDay(2454115.05486)) = "2001-10-9:hh:mm:ss";
+     * vle::utils::DateTime::toJulianDay(2454115.05486)) = "2001-10-9 hh:mm:ss";
      * @endcode
      * @param date The date to convert.
      * @return A string representation of the julian day.
@@ -252,7 +252,7 @@ public:
     /**
      * @brief Convert a string into a julian day.
      * @code
-     * vle::utils::DateTime::toJulianDay("2001-10-9:hh:mm:ss") = 2454115.05486;
+     * vle::utils::DateTime::toJulianDay("2001-10-9 hh:mm:ss") = 2454115.05486;
      * @endcode
      * @param date The date to convert.
      * @return A string representation of the julian day.

--- a/src/vle/utils/test/test1.cpp
+++ b/src/vle/utils/test/test1.cpp
@@ -326,6 +326,12 @@ BOOST_AUTO_TEST_CASE(julian_date)
 			vle::utils::DateTime::toJulianDayNumber("2001-10-9"));
 
     BOOST_TEST_MESSAGE("\nJulian day\n");
+
+    BOOST_REQUIRE_EQUAL("2007-01-14 01:18:59",
+                        vle::utils::DateTime::toJulianDay(2454115.05486));
+
+
+
     BOOST_REQUIRE_EQUAL(vle::utils::DateTime::toJulianDay(2454115.05486),
                         vle::utils::DateTime::toJulianDay(
 			    vle::utils::DateTime::toJulianDay(


### PR DESCRIPTION
When using the toJulianDay method in order to get a formated DateTime
String, for the month, the short name has been replaced by a decimal.