### PR TITLE
travis: added gcc 6, 7 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,39 @@ matrix:
       env:
         - CXX_COMPILER=g++-5 C_COMPILER=gcc-5
         - QT_SELECT=qt5
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - *common_packages
+            - g++-6
+      env:
+        - CXX_COMPILER=g++-6 C_COMPILER=gcc-6
+        - QT_SELECT=qt5
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - *common_packages
+            - g++-7
+      env:
+        - CXX_COMPILER=g++-7 C_COMPILER=gcc-7
+        - QT_SELECT=qt5
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - *common_packages
+            - g++-8
+      env:
+        - CXX_COMPILER=g++-8 C_COMPILER=gcc-8
+        - QT_SELECT=qt5
     - compiler: clang
       addons:
         apt:


### PR DESCRIPTION
More warnings and errors are produced with the latest gcc version.