### PR TITLE
gvle: add a button to reset the vle configuration file.

### DIFF
--- a/src/vle/gvle/gvle_win.cpp
+++ b/src/vle/gvle/gvle_win.cpp
@@ -158,6 +158,9 @@ gvle_win::gvle_win(QWidget* parent)
                      SIGNAL(toggled(bool)),
                      this,
                      SLOT(onSelectSimulator(bool)));
+
+    QObject::connect(
+      ui->actionResetConfig, SIGNAL(triggered()), this, SLOT(onResetConfig()));
     QObject::connect(
       ui->actionHelp, SIGNAL(triggered()), this, SLOT(onHelp()));
     QObject::connect(
@@ -796,6 +799,46 @@ gvle_win::onSelectSimulator(bool isChecked)
 }
 
 /**
+ * @brief gvle_win::onResetConfig Handler of menu Help > ResetConfig
+ *        Open a window asking if the userdoes want to reset the config
+ */
+void
+gvle_win::onResetConfig()
+{
+    QMessageBox::StandardButton reply;
+    reply = QMessageBox::critical(this,
+                                  tr("Question"),
+                                  tr("Are you sure you want to reset the vle" \
+                                     " configuration file to the default?"),
+                                  QMessageBox::Yes | QMessageBox::No);
+
+    if (reply == QMessageBox::Yes) {
+        mLogger->log(tr("Reset the vle configuration!"));
+        try {
+            using vle::utils::Path;
+
+            {
+                Path filepath(mCtx->getConfigurationFile());
+                filepath.remove();
+            }
+
+            {
+                Path filepath(mCtx->getLogFile());
+                filepath.remove();
+            }
+
+            mCtx->reset_settings();
+            mCtx->write_settings();
+        } catch (const std::exception& e) {
+            mLogger->log(QString(
+                             utils::format("Failed to reset the vle configuration file: %s\n",
+                                           e.what())
+                             .c_str()));
+        }
+    }
+}
+
+/**
  * @brief gvle_win::onHelp Handler of menu Help > Help
  *        Open a new tab and display embedded help page
  */
@@ -1002,7 +1045,7 @@ gvle_win::menuPackagesInstallRefresh()
                                 itb->major,
                                 itb->minor,
                                 itb->patch)
-                    .c_str()));
+                  .c_str()));
             }
         }
     }

--- a/src/vle/gvle/gvle_win.h
+++ b/src/vle/gvle/gvle_win.h
@@ -105,6 +105,7 @@ private slots:
     void onUndo();
     void onRedo();
     void onSelectSimulator(bool isChecked);
+    void onResetConfig();
     void onHelp();
     void onAbout();
     void onTabChange(int index);

--- a/src/vle/gvle/gvle_win.ui
+++ b/src/vle/gvle/gvle_win.ui
@@ -462,6 +462,7 @@ QPushButton:hover{background:url(:/icon/resources/icon/arrow_up_blue.png);}</str
     <property name="title">
      <string>&amp;Help</string>
     </property>
+    <addaction name="actionResetConfig"/>
     <addaction name="actionHelp"/>
     <addaction name="actionAbout"/>
    </widget>
@@ -637,6 +638,11 @@ QPushButton:hover{background:url(:/icon/resources/icon/arrow_up_blue.png);}</str
    </property>
    <property name="shortcut">
     <string>Ctrl+Q</string>
+   </property>
+  </action>
+  <action name="actionResetConfig">
+   <property name="text">
+    <string>Reset Config</string>
    </property>
   </action>
   <action name="actionAbout">


### PR DESCRIPTION
A new button is available on the help menu to reset the
configuration file.

closes: #360