### PR TITLE
gvle: add more flexible dependency list managment

### DIFF
--- a/src/vle/gvle/gvle_win.cpp
+++ b/src/vle/gvle/gvle_win.cpp
@@ -1684,7 +1684,8 @@ gvle_win::getPackageToBuildDepends()
          ++it) {
         QString line = *it;
         if (line.startsWith("Build-Depends: ")) {
-            line.replace("Build-Depends: ", "");
+            line.remove(' ');
+            line.replace("Build-Depends:", "");
             QStringList dep = line.split(",");
             dep.removeAll("");
             return dep;


### PR DESCRIPTION
White spaces are allowed in the Build-Depends list.